### PR TITLE
Add cronjobs async. revisions and replication

### DIFF
--- a/roles/yoda-rulesets/defaults/main.yml
+++ b/roles/yoda-rulesets/defaults/main.yml
@@ -18,6 +18,9 @@ core_rulesets:
 
 extra_rulesets:
 
+# UU Module specific configuration
+enable_async_replication: 1
+
 # Research module specific configuration.
 default_yoda_schema: default-0   # Default Yoda metadata scheme: default-0 or default-1
 enable_revisions: 1              # Enable revisions: yes (1) or no (0)

--- a/roles/yoda-rulesets/tasks/irods-ruleset-uu.yml
+++ b/roles/yoda-rulesets/tasks/irods-ruleset-uu.yml
@@ -111,7 +111,6 @@
     mode: 0755
   when: not ansible_check_mode
 
-
 - name: Find out if default metadata schema is installed
   become_user: "{{ irods_service_account }}"
   become: yes
@@ -352,3 +351,22 @@
     - /etc/irods/rules_research.py
     - /etc/irods/rules_research.pyc
     - /etc/irods/irods-ruleset-research/
+
+- name: Enable asynchronous replication job
+  become_user: "{{ irods_service_account }}"
+  become: yes
+  cron:
+    name: 'asynchronous-replication'
+    minute: '1,11,21,31,41,51'
+    job: '/bin/python /etc/irods/irods-ruleset-uu/tools/async-data-replicate.py >/dev/null 2>&1'
+  when: enable_async_replication == 1
+
+- name: Enable asynchronous revision creation job
+  become_user: "{{ irods_service_account }}"
+  become: yes
+  cron:
+    name: 'asynchronous-revisions'
+    minute: '6,16,26,36,46,56'
+    job: '/bin/python /etc/irods/irods-ruleset-uu/tools/async-data-revision.py >/dev/null 2>&1'
+  when: enable_revisions == 1
+


### PR DESCRIPTION
Add cronjobs for asynchronous replication and creation of revisions.
Variable enable_async_replication is numeric instead of boolean for
consistency with variable enable_revisions.

Will send separate PR for updating yoda-docs if this one is accepted.