### PR TITLE
add yoda_enable_httpd parameter

### DIFF
--- a/docs/administration/configuring-yoda.md
+++ b/docs/administration/configuring-yoda.md
@@ -117,6 +117,7 @@ yoda_environment             | Yoda environment: development, testing, acceptanc
 yoda_portal_fqdn             | Yoda Portal fully qualified domain name (FQDN)
 yoda_davrods_fqdn            | Yoda Davrods WebDAV fully qualified domain name (FQDN)
 yoda_davrods_anonymous_fqdn  | Yoda Davrods anonymous WebDAV fully qualified domain name (FQDN)
+yoda_enable_httpd            | Whether to enable the httpd service (boolean, default value: true). Set to false if manual actions are needed before starting the web server (e.g. mounting encrypted volumes)
 
 ### iRODS configuration
 

--- a/roles/apache/defaults/main.yml
+++ b/roles/apache/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+
+yoda_enable_httpd: true

--- a/roles/apache/tasks/main.yml
+++ b/roles/apache/tasks/main.yml
@@ -47,8 +47,8 @@
   - /etc/httpd/conf.d/autoindex.conf
 
 
-- name: Ensure Apache is running and enabled
+- name: Ensure Apache service is configured
   service:
     name: httpd
     state: started
-    enabled: yes
+    enabled: '{{ yoda_enable_httpd }}'


### PR DESCRIPTION
Intended to be used in situations where httpd should only be started
after manual actions (such as mounting encrypted volumes).

If accepted, please merge into release-1.5 and release-1.6 branches.