### PR TITLE
Yda 3872 - Upgrade from 1.5 installs iRODS 4.2.8 packages instead of 4.2.7

### DIFF
--- a/docs/release-notes/release-1.6.md
+++ b/docs/release-notes/release-1.6.md
@@ -70,7 +70,7 @@ ansible-playbook -i <path-to-your-environment> playbook.yml --check
 ansible-playbook -i /environments/development/allinone playbook.yml --check
 ```
 
-7. If the palybook has finished succesfully in check mode, run the Ansible playbook normally.
+7. If the playbook has finished succesfully in check mode, run the Ansible playbook normally.
 ```bash
 ansible-playbook -i <path-to-your-environment> playbook.yml
 ### EXAMPLE ###

--- a/docs/release-notes/release-1.6.md
+++ b/docs/release-notes/release-1.6.md
@@ -21,19 +21,21 @@ Upgrade is supported by Ansible (2.9.x).
 Requires Yoda external user service to be on version 1.5.x or higher.
 Requires Yoda public server to be on version 1.6.x or higher.
 
-1. Set Yoda release to `release-1.6` in configuration.
-```yaml
-yoda_version: release-1.6
-```
+1. Backup/copy custom configurations made to Yoda version 1.5.
+To view what files were changed from the defaults, run `git diff`.
 
-2. Set the default schema to `default-1` in configuration.
-```yaml
-default_yoda_schema: default-1
-```
+2. After making sure the configurations are stored safely in another folder, reset the Yoda folder using `git stash` or when you want to delete all changes made: `git reset --hard`.
 
-3. The core modules (`research`, `vault`, `statistics`, `group-manager`) are enabled by default in Yoda 1.6.
+3. Checkout branch `release-1.6` of the Yoda Git repository
+```bash
+git checkout release-1.6
+```
+This will set Yoda release to `release-1.6` in configuration as well as the default schema to `default-1`.
+
+4. The core modules (`research`, `vault`, `statistics`, `group-manager`) are enabled by default in Yoda 1.6.
    Only extra modules have to be enabled in the configuration.
    So `modules` becomes `extra_modules` and all core modules should be removed from the `extra_modules` list.
+   Update the configuration according to your specifications.
    For example:
     ```yaml
     # Yoda modules
@@ -44,11 +46,12 @@ default_yoda_schema: default-1
         version: "{{ yoda_version }}"
     ```
 
-4. The core rulesets (`core` and `irods-ruleset-uu`) are enabled by default in Yoda 1.6.
+5. The core rulesets (`core` and `irods-ruleset-uu`) are enabled by default in Yoda 1.6.
    Only extra modules have to be enabled in the configuration.
    Furthermore, the research ruleset (`irods-ruleset-research`) has been merged with the UU ruleset
    (`irods-ruleset-uu`). So `rulesets` becomes `extra_rulesets`;
    `core`, `irods-ruleset-research` and `irods-ruleset-uu` should be removed from the `extra_rulesets` list.
+   Update the configuration according to your specifications.
    For example:
     ```yaml
     # iRODS rulesets
@@ -60,21 +63,31 @@ default_yoda_schema: default-1
         install_scripts: no
     ```
 
-5. Run the Ansible upgrade in check mode.
+6. Run the Ansible playbook in check mode.
+```bash
+ansible-playbook -i <path-to-your-environment> playbook.yml --check
+### EXAMPLE ###
+ansible-playbook -i /environments/development/allinone playbook.yml --check
+```
 
-6. Run the Ansible upgrade.
+7. If the palybook has finished succesfully in check mode, run the Ansible playbook normally.
+```bash
+ansible-playbook -i <path-to-your-environment> playbook.yml
+### EXAMPLE ###
+ansible-playbook -i /environments/development/allinone playbook.yml
+```
 
-7. Convert all metadata XML in the vault to JSON (`default-0` XML to `default-0` JSON).
+8. Convert all metadata XML in the vault to JSON (`default-0` XML to `default-0` JSON).
 ```bash
 irule -r irods_rule_engine_plugin-irods_rule_language-instance -F /etc/irods/irods-ruleset-uu/tools/check-vault-metadata-xml-for-transformation-to-json.r
 ```
 
-8. Update all metadata JSON in the vault to latest metadata JSON version (`default-0` to `default-1`).
+9. Update all metadata JSON in the vault to latest metadata JSON version (`default-0` to `default-1`).
 ```bash
 irule -r irods_rule_engine_plugin-irods_rule_language-instance -F /etc/irods/irods-ruleset-uu/tools/check-metadata-for-schema-updates.r
 ```
 
-9. Update publication endpoints if there are published packages (landingpages and OAI-PMH)):
+10. Update publication endpoints if there are published packages (landingpages and OAI-PMH)):
 ```bash
 irule -r irods_rule_engine_plugin-irods_rule_language-instance -F /etc/irods/irods-ruleset-uu/tools/update-publications.r
 ```

--- a/roles/irods_icat/tasks/main.yml
+++ b/roles/irods_icat/tasks/main.yml
@@ -4,9 +4,14 @@
 - name: Ensure iRODS 4.2.6 packages are absent
   package:
     name:
-      - irods-uu-microservices-4.2.6_0.8.0-1
-      - irods-sudo-microservices-4.2.6_1.0.0-1
-      - davrods-4.2.6_1.4.2-1
+      - irods-uu-microservices-4.2.6_0.8.0
+      - irods-sudo-microservices-4.2.6_1.0.0
+      - davrods-4.2.6_1.4.2
+      - irods-runtime-4.2.6
+      - irods-server-4.2.6
+      - irods-rule-engine-plugin-python-4.2.6
+      - irods-icommands-4.2.6
+      - irods-database-plugin-postgres-4.2.6
     state: absent
 
 
@@ -19,6 +24,12 @@
       - irods-rule-engine-plugin-python-4.2.7-1
     state: present
   when: not ansible_check_mode
+
+
+- name: Restart the iRODS server
+  become_user: '{{ irods_service_account }}'
+  become: yes
+  command: '/var/lib/irods/irodsctl restart'
 
 
 - name: Ensure default msiExecCmd binaries are absent
@@ -199,6 +210,7 @@
   become: yes
   command: '/var/lib/irods/irodsctl start'
   when: ils is failed
+  check_mode: false
 
 
 - name: Wait until iRODS server is ready to receive requests

--- a/roles/irods_icat/tasks/main.yml
+++ b/roles/irods_icat/tasks/main.yml
@@ -24,13 +24,14 @@
       - irods-rule-engine-plugin-python-4.2.7-1
     state: present
   when: not ansible_check_mode
+  register: irods_uninstalled
 
 
 - name: Restart the iRODS server
   become_user: '{{ irods_service_account }}'
   become: yes
   command: '/var/lib/irods/irodsctl restart'
-  changed_when: false
+  when: irods_uninstalled is defined and irods_uninstalled.changed
 
 
 - name: Ensure default msiExecCmd binaries are absent

--- a/roles/irods_icat/tasks/main.yml
+++ b/roles/irods_icat/tasks/main.yml
@@ -30,6 +30,7 @@
   become_user: '{{ irods_service_account }}'
   become: yes
   command: '/var/lib/irods/irodsctl restart'
+  changed_when: false
 
 
 - name: Ensure default msiExecCmd binaries are absent

--- a/roles/irods_icommands/tasks/main.yml
+++ b/roles/irods_icommands/tasks/main.yml
@@ -10,9 +10,14 @@
 - name: Ensure iRODS 4.2.6 packages are absent
   package:
     name:
-      - irods-uu-microservices-4.2.6_0.8.0-1
-      - irods-sudo-microservices-4.2.6_1.0.0-1
-      - davrods-4.2.6_1.4.2-1
+      - irods-uu-microservices-4.2.6_0.8.0
+      - irods-sudo-microservices-4.2.6_1.0.0
+      - davrods-4.2.6_1.4.2
+      - irods-runtime-4.2.6
+      - irods-server-4.2.6
+      - irods-rule-engine-plugin-python-4.2.6
+      - irods-icommands-4.2.6
+      - irods-database-plugin-postgres-4.2.6
     state: absent
 
 

--- a/roles/irods_microservices/tasks/main.yml
+++ b/roles/irods_microservices/tasks/main.yml
@@ -11,9 +11,14 @@
 - name: Ensure iRODS 4.2.6 packages are absent
   package:
     name:
-      - irods-uu-microservices-4.2.6_0.8.0-1
-      - irods-sudo-microservices-4.2.6_1.0.0-1
-      - davrods-4.2.6_1.4.2-1
+      - irods-uu-microservices-4.2.6_0.8.0
+      - irods-sudo-microservices-4.2.6_1.0.0
+      - davrods-4.2.6_1.4.2
+      - irods-runtime-4.2.6
+      - irods-server-4.2.6
+      - irods-rule-engine-plugin-python-4.2.6
+      - irods-icommands-4.2.6
+      - irods-database-plugin-postgres-4.2.6
     state: absent
 
 

--- a/roles/irods_resource/tasks/main.yml
+++ b/roles/irods_resource/tasks/main.yml
@@ -4,9 +4,14 @@
 - name: Ensure iRODS 4.2.6 packages are absent
   package:
     name:
-      - irods-uu-microservices-4.2.6_0.8.0-1
-      - irods-sudo-microservices-4.2.6_1.0.0-1
-      - davrods-4.2.6_1.4.2-1
+      - irods-uu-microservices-4.2.6_0.8.0
+      - irods-sudo-microservices-4.2.6_1.0.0
+      - davrods-4.2.6_1.4.2
+      - irods-runtime-4.2.6
+      - irods-server-4.2.6
+      - irods-rule-engine-plugin-python-4.2.6
+      - irods-icommands-4.2.6
+      - irods-database-plugin-postgres-4.2.6
     state: absent
 
 

--- a/roles/irods_runtime/tasks/main.yml
+++ b/roles/irods_runtime/tasks/main.yml
@@ -4,9 +4,14 @@
 - name: Ensure iRODS 4.2.6 packages are absent
   package:
     name:
-      - irods-uu-microservices-4.2.6_0.8.0-1
-      - irods-sudo-microservices-4.2.6_1.0.0-1
-      - davrods-4.2.6_1.4.2-1
+      - irods-uu-microservices-4.2.6_0.8.0
+      - irods-sudo-microservices-4.2.6_1.0.0
+      - davrods-4.2.6_1.4.2
+      - irods-runtime-4.2.6
+      - irods-server-4.2.6
+      - irods-rule-engine-plugin-python-4.2.6
+      - irods-icommands-4.2.6
+      - irods-database-plugin-postgres-4.2.6
     state: absent
 
 


### PR DESCRIPTION
When installing a new version for a iRODS 4.2.6 package the dependecies cause an issues that has the package manager install the 4.2.8 versions, which should not be installed.
The dependencies on the packages themselves seem correct, but somehow don't work together nicely with yum.
Encountered behaviour: 
  Only iRODS package installed irods-runtime-4.2.6 and update: updates to 4.2.7
  iRODS runtime and iCommands 4.2.6 installed and update only iCommands: both packages are updated to 4.2.8

Workaround: removing all 4.2.6 packages before installing any 4.2.7 packages.
Needs to be tested on ACC; tested on dev (upgrade from 1.5 as well as clean install).