### PR TITLE
Ansible-lint action: pin ansible package version

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -22,6 +22,9 @@ jobs:
       with:
         targets: |
           playbook.yml
+        override-deps: |
+          ansible==2.10
+          ansible-lint==4.3.7
 
         # [optional]
         # Arguments to be passed to the ansible-lint


### PR DESCRIPTION
Pin Ansible pip package on v2.10.x, so that the lint action doesn't fail because
of trying to parse this Ansible 2.x playbook using the newly released
Ansible 3.x package