### PR TITLE
Pyportal auth

### DIFF
--- a/environments/development/allinone/group_vars/allinone.yml
+++ b/environments/development/allinone/group_vars/allinone.yml
@@ -164,10 +164,10 @@ eus_smtp_password: PLACEHOLDER
 eus_smtp_from_address: PLACEHOLDER
 eus_smtp_replyto_address: PLACEHOLDER
 eus_mail_template: uu
-external_users_domain_filter: uu.nl|gmail.com     # Domains to filter, separated by |
+external_users_domain_filter: uu.nl     # Domains to filter, separated by |
 
 # Openid Connect configuration (This configuration is for TESTING purposes!)
-oidc_active: true
+oidc_active: false
 oidc_client_id: myClientId                                    # OIDC Client Id
 oidc_client_secret: myClientPassword                          # OIDC Client Secret/Password
 oidc_callback_url: https://portal.yoda.test/user/callback     # OIDC Callback url

--- a/environments/development/allinone/group_vars/allinone.yml
+++ b/environments/development/allinone/group_vars/allinone.yml
@@ -164,10 +164,10 @@ eus_smtp_password: PLACEHOLDER
 eus_smtp_from_address: PLACEHOLDER
 eus_smtp_replyto_address: PLACEHOLDER
 eus_mail_template: uu
-external_users_domain: gmail.com
+external_users_domain_filter: uu.nl|gmail.com     # Domains to filter, separated by |
 
 # Openid Connect configuration (This configuration is for TESTING purposes!)
-oidc_active: false
+oidc_active: true
 oidc_client_id: myClientId                                    # OIDC Client Id
 oidc_client_secret: myClientPassword                          # OIDC Client Secret/Password
 oidc_callback_url: https://portal.yoda.test/user/callback     # OIDC Callback url

--- a/roles/irods_icat/defaults/main.yml
+++ b/roles/irods_icat/defaults/main.yml
@@ -31,7 +31,7 @@ pam_radius_config: |
 
 # External Users configuration
 external_users: True
-external_users_domain: uu.nl
+external_users_domain_filter: uu.nl
 eus_api_fqdn: eus.yoda.test
 eus_api_port: 8443
 eus_api_secret: PLACEHOLDER

--- a/roles/irods_icat/templates/irods_pam.j2
+++ b/roles/irods_icat/templates/irods_pam.j2
@@ -4,13 +4,13 @@
 auth        optional      pam_faildelay.so delay={{ pam_fail_delay }}
 auth        sufficient    pam_unix.so
 
+{% if oidc_active is defined and oidc_active is sameas true %}
+auth        sufficient      pam_python.so /var/lib/irods/msiExecCmd_bin/oidc.py
+{% endif %}
+
 {% if external_users %}
 auth [success=ignore default=1] pam_exec.so /usr/local/bin/is-user-external.sh
 auth [success=done default=die] pam_exec.so expose_authtok /usr/local/bin/external-auth.py
 {% endif %}
 
-{% if oidc_active is defined and oidc_active is sameas true %}
-auth        sufficient    pam_radius_auth.so
-auth        required      pam_python.so /var/lib/irods/msiExecCmd_bin/oidc.py {% else %}
 auth        required      pam_radius_auth.so
-{% endif %}

--- a/roles/irods_icat/templates/is-user-external.sh.j2
+++ b/roles/irods_icat/templates/is-user-external.sh.j2
@@ -1,8 +1,8 @@
 #!/bin/bash
 # {{ ansible_managed }}
 
-{% if external_users_domain  %}
-[[ "$PAM_USER" =~ .*@.* ]] && [[ ! "$PAM_USER" =~ [.@]{{external_users_domain}}$ ]]
+{% if external_users_domain_filter  %}
+[[ "$PAM_USER" =~ .*@.* ]] && [[ ! "$PAM_USER" =~ [.@]({{external_users_domain_filter | replace('.', '\.')}})$ ]]
 {% else %}
 [[ "$PAM_USER" =~ .*@.* ]]
 {% endif %}

--- a/roles/irods_icat/templates/oidc.py.j2
+++ b/roles/irods_icat/templates/oidc.py.j2
@@ -5,7 +5,8 @@ import requests
 
 
 USERINFO_URI = "{{ oidc_userinfo_uri | default('') }}"
-
+EMAIL_FIELD = "{{ oidc_email_field | default('email') }}"
+ 
 def validate_token(username, token):
     # Send token validation request.
     headers = {"Authorization": "Bearer {}".format(token)}
@@ -13,12 +14,18 @@ def validate_token(username, token):
 
     # Check http status.
     if r.status_code != 200:
+        print('Failed to get a successful userinfo response '
+              '\n{}\n{}'
+              .format(r.status_code, r.text))
         return False
 
     # Retrieve token email.
     try:
-        email = r.json()["{{ oidc_email_field | default('email') }}"]
+        email = r.json()[EMAIL_FIELD].lower()
     except Exception:
+        print('Unable to retrieve the email address from '
+              'the userinfo response.\nKey: {}\nUserinfo:\n{}'
+              .format(EMAIL_FIELD, r.text))
         return False
 
     # Check if token email corresponds with username.
@@ -33,15 +40,25 @@ def pam_sm_authenticate(pamh, flags, argv):
     try:
         username = pamh.get_user()
     except Exception:
+        print('User unknown')
         return pamh.PAM_USER_UNKNOWN
 
     # Get the token.
     token = pamh.authtok
     if token is None:
+        print('Missing token')
         return pamh.PAM_AUTH_ERR
+
+    # Remove the prefix from the portal.
+    if token[0:14] == '++oidc_token++':
+        token = token[14:]
+    else:
+        print('Not an oidc token')
+        return pamh.PAM_PERM_DENIED
 
     # Validate the token.
     if(validate_token(username, token)):
         return pamh.PAM_SUCCESS
 
+    print('Validation failed')
     return pamh.PAM_AUTH_ERR


### PR DESCRIPTION
Changes:
- oidc.py now copmutes the lower case version of the email retrieved (this was missing)
- More logging in oidc.py for functional management
- Added a prefix to the token so the PAM stack can execute the correct authentication method instead of trying them all (partly in yoda-portal repository)
- Restructured the PAM stack so OIDC works in tandem with the external user service
- Renamed 'external_users_domain' to 'external_users_domain_filter' to better capture the functionality and changed its default value (this solves YDA-4044)