### PR TITLE
Integrate intake move2vault job in playbook

### DIFF
--- a/docs/administration/configuring-yoda.md
+++ b/docs/administration/configuring-yoda.md
@@ -154,6 +154,7 @@ credential_files             | Location of Yoda credentials files
 Variable                     | Description
 -----------------------------|---------------------
 enable_intake                | Enable intake module
+intake_groups                | List of intake groups (without the "grp-intake-" prefix)
 
 ### Datarequest module configuration
 

--- a/roles/yoda_rulesets/defaults/main.yml
+++ b/roles/yoda_rulesets/defaults/main.yml
@@ -71,6 +71,9 @@ eus_api_port: 8443                      # External User Service API port
 eus_api_secret: PLACEHOLDER             # External User Service API secret
 
 enable_intake: false                    # Enable intake module
+intake_groups: []                       # List of intake_groups. Use the names without "grp-intake-"
+                                        # For example: "projectabc" for "grp-intake-projectabc"
+
 enable_datarequest: false               # Enable datarequest module
 
 yoda_portal_fqdn: PLACEHOLDER           # Yoda portal FQDN

--- a/roles/yoda_rulesets/tasks/irods-ruleset-uu.yml
+++ b/roles/yoda_rulesets/tasks/irods-ruleset-uu.yml
@@ -237,6 +237,17 @@
     group: '{{ irods_service_account }}'
     mode: '0644'
 
+- name: Install script for moving intake collections to the vault
+  become_user: "{{ irods_service_account }}"
+  become: yes
+  template:
+    src: job_movetovault.r.j2
+    dest: '~{{ irods_service_account }}/.irods/job_movetovault.r'
+    owner: '{{ irods_service_account }}'
+    group: '{{ irods_service_account }}'
+    mode: '0644'
+  # This script is provided by the test playbook for development/test servers.
+  when: enable_intake and yoda_environment not in ["development","testing"]
 
 - name: Configure cronjob to process publications
   become_user: "{{ irods_service_account }}"
@@ -264,6 +275,19 @@
     minute: '0'
     hour: '2'
     job: '/bin/bash /var/lib/irods/.irods/cronjob-revision-cleanup.sh >> /var/lib/irods/log/cronjob-revision-cleanup.log 2>&1'
+
+
+- name: Configure cronjob for moving collections from intake to vault
+  become_user: "{{ irods_service_account }}"
+  become: yes
+  cron:
+    name: 'job_movetovault.r'
+    minute: '*/5'
+    job: >
+      /bin/irule -r irods_rule_engine_plugin-irods_rule_language-instance -F
+      /var/lib/irods/.irods/job_movetovault.r >>$HOME/iRODS/server/log/job_movetovault.log 2>&1
+  # This script is provided by the test playbook for development/test servers.
+  when: enable_intake and yoda_environment not in ["development","testing"]
 
 
 - name: Ensure that ExecCmd dir exists

--- a/roles/yoda_rulesets/templates/job_movetovault.r.j2
+++ b/roles/yoda_rulesets/templates/job_movetovault.r.j2
@@ -1,0 +1,40 @@
+# \file
+# \brief job
+# \author Ton Smeele
+# \copyright Copyright (c) 2015, Utrecht university. All rights reserved
+# \license GPLv3, see LICENSE
+#
+#  This file should be executed as part of a recurring crontab job
+#  as the irods admin user (i.e. irods user type rodsadmin)
+#  e.g. run every 5 minutes
+#
+#  if another instance of the job is running then the vault will be
+#  locked and silently ignored
+#
+
+uuYcRunIntake2Vault {
+	# intake areas can be added to the grouplist as needed
+	*grouplist = list ( {{ intake_groups | map("regex_replace","(.+)",'\"\\1\"') | join(',') }} );
+	*zone = $rodsZoneClient;
+
+	foreach (*grp in *grouplist) {
+		*intakeRoot = "/*zone/home/grp-intake-*grp";
+		*vaultRoot  = "/*zone/home/grp-vault-*grp";
+		uuLock(*vaultRoot, *status);
+		# FIX ME: currently we ignore existing locks
+		# because locks are not removed when the rule exist with error
+		# need a more robust solution for this!
+		*status = 0; 
+		if (*status == 0) {
+			# we have a lock
+			uuYc2Vault(*intakeRoot, *vaultRoot, *status);
+			if (*status == 0 ) then *result = "ok" else *result = "ERROR (*status)";
+			writeLine("serverLog","RunIntake2Vault for *intakeRoot result = *result");
+			uuUnlock(*vaultRoot);
+		}
+	}
+}
+
+
+input *intakeRoot='dummy'
+output ruleExecOut


### PR DESCRIPTION
Job_move2vault script has been included as-is, except that *grouplist contents are configured by Ansible.

If accepted, please cherry-pick into release-1.7 branch as well.