### PR TITLE
YDA-4233: fix installation DR module schemas

### DIFF
--- a/roles/yoda_rulesets/tasks/irods-ruleset-uu.yml
+++ b/roles/yoda_rulesets/tasks/irods-ruleset-uu.yml
@@ -386,11 +386,21 @@
   when: enable_datarequest and not ansible_check_mode and datarequest_system_collection.stderr.find('does not exist') >= 0
 
 
-- name: Ensure datarequest schemas exist
+- name: Find out if datarequest schema collection exists
+  become_user: "{{ irods_service_account }}"
+  become: yes
+  command: 'ils /{{ irods_zone }}/yoda/datarequest/schemas'
+  ignore_errors: True
+  register: datarequest_schema_collection
+  changed_when: False
+  when: enable_datarequest and not ansible_check_mode
+
+
+- name: Install default datarequest module schemas if they do not exist
   become_user: "{{ irods_service_account }}"
   become: yes
   command: "/etc/irods/irods-ruleset-uu/tools/install-datarequest-schemas.sh '{{ irods_zone }}'"
-  when: enable_datarequest and not ansible_check_mode
+  when: enable_datarequest and not ansible_check_mode and datarequest_schema_collection.stderr.find('does not exist') >= 0
 
 
 - name: Find out if Yoda data requests data directory is present


### PR DESCRIPTION
Customized schemas for the datarequest module should not be overwritten by
the Ansible playbook.

If accepted, please cherry pick to release-1.7 branch as well.