### PR TITLE
YDA-4241: fix outdated example config

### DIFF
--- a/docs/administration/configuring-yoda.md
+++ b/docs/administration/configuring-yoda.md
@@ -31,28 +31,30 @@ In the inventory the hosts of an instance are defined, their functional roles an
 Example configuration defining the and functional roles of an instance called 'yoda':
 ```bash
 [yoda:children]
-host1.yoda.test
-host2.yoda.test
-host3.yoda.test
-host4.yoda.test
+yoda_portal
+yoda_database
+yoda_icat
+yoda_resource
+yoda_public
+yoda_eus
 
-[yoda-portal]
+[yoda_portal]
 host1.yoda.test
 
 # leave this out when using an existing database for ICAT
-[yoda-database]
+[yoda_database]
 host1.yoda.test
 
-[yoda-icat]
+[yoda_icat]
 host1.yoda.test
 
-[yoda-resource]
+[yoda_resource]
 host2.yoda.test
 
-[yoda-public]
+[yoda_public]
 host3.yoda.test
 
-[yoda-eus]
+[yoda_eus]
 host4.yoda.test
 ```
 
@@ -60,23 +62,23 @@ Add the new functional roles of the instance to the corresponding groups.
 For example:
 ```bash
 [portals:children]
-yoda-portal
+yoda_portal
 
 # leave this out when using an existing database for ICAT
 [databases:children]
-yoda-database
+yoda_database
 
 [icats:children]
-yoda-icat
+yoda_icat
 
 [resources:children]
-yoda-resource
+yoda_resource
 
 [publics:children]
-yoda-public
+yoda_public
 
 [eus:children]
-yoda-eus
+yoda_eus
 ```
 
 Last step to add the hosts of a new Yoda instance is to create configuration files for every new host.


### PR DESCRIPTION
- Use groups instead of individual hosts when referring to :children
- Don't use dashes in group names (this is deprecated)