### PR TITLE
YDA-4216: add resource_trigger_pol option

### DIFF
--- a/docs/administration/configuring-yoda.md
+++ b/docs/administration/configuring-yoda.md
@@ -135,6 +135,7 @@ irods_icat_fqdn              | iRODS iCAT fully qualified domain name (FQDN)
 irods_database_fqdn          | iRODS database fully qualified domain name (FQDN)
 irods_resource_fqdn          | iRODS resource fully qualified domain name (FQDN)
 irods_default_resc           | iRODS default resource name
+irods_resc_trigger_pol       | List of text patterns for matching non-primary resources where changes also need to trigger policies (e.g. asynchronous replication). Example: ["^testResc$","^myResc$"]
 irods_ssl_verify_server      | Verify TLS certificate, use 'cert' for acceptance and production
 irods_resources              | Definition of iRODS resources of this Yoda instance
 irods_service_type           | Possible values: 'sysv' (System V) or 'systemd'

--- a/roles/yoda_rulesets/defaults/main.yml
+++ b/roles/yoda_rulesets/defaults/main.yml
@@ -32,6 +32,7 @@ update_schemas: 0                # Update already installed schemas, formelement
 yoda_random_id_length: 6         # Length of random ID to add to persistent identifier
 irods_default_resc: irodsResc
 irods_repl_resc: irodsRescRepl
+irods_resc_trigger_pol: []
 
 # SURF config: separate resources for research and vault
 resource_research: "{{ irods_default_resc }}"

--- a/roles/yoda_rulesets/templates/rules_uu.cfg.j2
+++ b/roles/yoda_rulesets/templates/rules_uu.cfg.j2
@@ -13,6 +13,7 @@ resource_primary           = '{{ irods_default_resc }}'
 resource_replica           = '{{ irods_repl_resc }}'
 resource_research          = '{{ resource_research }}'
 resource_vault             = '{{ resource_vault }}'
+resource_trigger_pol      = '{{ irods_resc_trigger_pol | join (" ") }}'
 
 notifications_enabled      = '{{ ["false", "true"][send_notifications|int] }}'
 notifications_sender_email = '{{ notifications_sender_email }}'


### PR DESCRIPTION
If accepted, please also merge into release-1.7 branch.

---

For providing text patterns to match names of resources other than the
primary resource that should have policies (e.g. asynchronous revision
and replication) enabled.