### PR TITLE
Prevent duplicate http(s) ports

### DIFF
--- a/roles/apache/templates/httpd.conf.j2
+++ b/roles/apache/templates/httpd.conf.j2
@@ -54,6 +54,10 @@ ServerRoot "/etc/httpd"
 #Listen 12.34.56.78:80
 Listen 80
 
+{% if eus_api_port != yoda_davrods_anonymous_port %}
+Listen {{ eus_api_port }}
+{% endif %}
+
 #
 # Dynamic Shared Object (DSO) Support
 #

--- a/roles/apache/templates/ssl.conf.j2
+++ b/roles/apache/templates/ssl.conf.j2
@@ -5,6 +5,18 @@
 #
 Listen 443 https
 
+{% if yoda_davrods_port != 443 %}
+Listen {{ yoda_davrods_port }}
+{% endif %}
+
+{% if yoda_davrods_anonymous_port != 443 %}
+Listen {{ yoda_davrods_anonymous_port }}
+{% endif %}
+
+{% if yoda_public_port != 443 %}
+Listen {{ yoda_public_port }}
+{% endif %}
+
 ##
 ##  SSL Global Context
 ##

--- a/roles/yoda_davrods/templates/davrods-anonymous-vhost.conf.j2
+++ b/roles/yoda_davrods/templates/davrods-anonymous-vhost.conf.j2
@@ -8,10 +8,6 @@
 # its default options.
 #
 
-{% if yoda_davrods_anonymous_port != 443 %}
-Listen {{ yoda_davrods_anonymous_port }}
-{% endif %}
-
 <VirtualHost *:{{ yoda_davrods_anonymous_port }}>
 
     # Enter your server name here.

--- a/roles/yoda_davrods/templates/davrods-vhost.conf.j2
+++ b/roles/yoda_davrods/templates/davrods-vhost.conf.j2
@@ -8,10 +8,6 @@
 # its default options.
 #
 
-{% if yoda_davrods_port != 443 %}
-Listen {{ yoda_davrods_port }}
-{% endif %}
-
 <VirtualHost *:{{ yoda_davrods_port }}>
 
     # Enter your server name here.

--- a/roles/yoda_external_user_service/templates/yoda-external-user-service-vhost.conf.j2
+++ b/roles/yoda_external_user_service/templates/yoda-external-user-service-vhost.conf.j2
@@ -42,7 +42,6 @@
     SSLCertificateKeyFile   {{ openssl_private_dir }}/{{ openssl_key_signed }}
 </VirtualHost>
 
-Listen {{ eus_api_port }}
 <VirtualHost *:{{ eus_api_port }}>
     DocumentRoot "/var/www/extuser/api"
     ServerName {{ eus_api_fqdn }}

--- a/roles/yoda_public/templates/yoda-public-vhost.conf.j2
+++ b/roles/yoda_public/templates/yoda-public-vhost.conf.j2
@@ -1,10 +1,6 @@
 # {{ ansible_managed }}
 # yoda-public-vhost.conf
 
-{% if yoda_public_port != 443 %}
-Listen {{ yoda_public_port }}
-{% endif %}
-
 <VirtualHost *:{{ yoda_public_port }}>
     DocumentRoot {{ landingpages_root }}
     ServerName {{ yoda_public_fqdn }}


### PR DESCRIPTION
Prevent multiple 'Listen' entries in Apache httpd vhost confs
E.g. 'Listen 8443' (for both EUS and davrods) making restart fail: 'addr already in use'