### PR TITLE
Don't log changes to portal local config [1.7]

### DIFF
--- a/roles/yoda_portal/tasks/main.yml
+++ b/roles/yoda_portal/tasks/main.yml
@@ -113,6 +113,7 @@
     dest: /var/www/yoda/yoda-portal/config/config_local.php
     owner: "{{ yoda_deployment_user }}"
     mode: 0644
+  no_log: true
   when: not ansible_check_mode
 
 


### PR DESCRIPTION
This file can contain OIDC client secrets, which shouldn't be printed to the logs.