### PR TITLE
Don't log changes to flask.cfg

### DIFF
--- a/roles/yoda_portal/tasks/main.yml
+++ b/roles/yoda_portal/tasks/main.yml
@@ -75,6 +75,7 @@
     src: "flask.cfg.j2"
     dest: "/var/www/yoda/flask.cfg"
     mode: '0644'
+  no_log: true
 
 
 - name: Copy Yoda Portal virtual host config for Apache


### PR DESCRIPTION
It may contain an OIDC client secret, which shouldn't end up in the Ansible logs