### PR TITLE
Set rule engine server sleep time to 10 seconds.

### DIFF
--- a/roles/irods_icat/tasks/main.yml
+++ b/roles/irods_icat/tasks/main.yml
@@ -191,13 +191,13 @@
     value: '{{ irods_icat_fqdn }}'
 
 
-- name: Set delayed rule sleep time to 1 second
+- name: Set delayed rule sleep time to 10 seconds
   become_user: '{{ irods_service_account }}'
   become: yes
   irods_advanced:
     path: '/etc/irods/server_config.json'
     key: 'rule_engine_server_sleep_time_in_seconds'
-    value: '1'
+    value: '10'
 
 
 - name: Ensure core.re is configured

--- a/roles/irods_icat/templates/setup_irods_provider.json.j2
+++ b/roles/irods_icat/templates/setup_irods_provider.json.j2
@@ -36,7 +36,7 @@
       "maximum_size_for_single_buffer_in_megabytes": 32,
       "maximum_temporary_password_lifetime_in_seconds": 1000,
       "rule_engine_server_execution_time_in_seconds": 120,
-      "rule_engine_server_sleep_time_in_seconds": 1,
+      "rule_engine_server_sleep_time_in_seconds": 10,
       "transfer_buffer_size_for_parallel_transfer_in_megabytes": 4,
       "transfer_chunk_size_for_parallel_transfer_in_megabytes": 40
     },

--- a/roles/irods_resource/templates/setup_irods_consumer.json.j2
+++ b/roles/irods_resource/templates/setup_irods_consumer.json.j2
@@ -36,7 +36,7 @@
       "maximum_size_for_single_buffer_in_megabytes": 32,
       "maximum_temporary_password_lifetime_in_seconds": 1000,
       "rule_engine_server_execution_time_in_seconds": 120,
-      "rule_engine_server_sleep_time_in_seconds": 1,
+      "rule_engine_server_sleep_time_in_seconds": 10,
       "transfer_buffer_size_for_parallel_transfer_in_megabytes": 4,
       "transfer_chunk_size_for_parallel_transfer_in_megabytes": 40
     },


### PR DESCRIPTION
The iRODS default is 30 seconds. We set this to 1 second because we used the delayed rule engine for revisions and replications. We now only use the delayed rule engine for copy to vault and vault schema transformations.