### PR TITLE
YDA-4407: fix intake movetovault locks

### DIFF
--- a/roles/yoda_rulesets/files/run-intake-movetovault.sh
+++ b/roles/yoda_rulesets/files/run-intake-movetovault.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+/bin/irule -r irods_rule_engine_plugin-irods_rule_language-instance \
+      -F /var/lib/irods/.irods/job_movetovault.r \
+      >>$HOME/iRODS/server/log/job_movetovault.log 2>&1
+
+# Check if the job is still running. This can happen if the previous
+# job hasn't finished before this one started. In this case, the previous
+# job will clear the locks when it's finished, so this job should
+# leave the locks in place.
+if pgrep -u irods -f /var/lib/irods/.irods/job_movetovault.r >& /dev/null
+then echo "job_movetovault still running; not clearing locks ..."
+else /bin/irule -r irods_rule_engine_plugin-irods_rule_language-instance \
+          -F /var/lib/irods/.irods/job_clearintakelocks.r 2>&1
+fi

--- a/roles/yoda_rulesets/tasks/yoda-ruleset.yml
+++ b/roles/yoda_rulesets/tasks/yoda-ruleset.yml
@@ -249,6 +249,7 @@
     group: '{{ irods_service_account }}'
     mode: '0644'
 
+
 - name: Install script for moving intake collections to the vault
   become_user: "{{ irods_service_account }}"
   become: yes
@@ -258,8 +259,22 @@
     owner: '{{ irods_service_account }}'
     group: '{{ irods_service_account }}'
     mode: '0644'
+  # This script is provided by the yoda_test rule for development/test servers.
+  when: enable_intake and yoda_environment not in ["development","testing"]
+
+
+- name: Install script for clearing locks after moving intake collections
+  become_user: "{{ irods_service_account }}"
+  become: yes
+  template:
+    src: job_clearintakelocks.r.j2
+    dest: '~{{ irods_service_account }}/.irods/job_clearintakelocks.r'
+    owner: '{{ irods_service_account }}'
+    group: '{{ irods_service_account }}'
+    mode: '0644'
   # This script is provided by the test playbook for development/test servers.
   when: enable_intake and yoda_environment not in ["development","testing"]
+
 
 - name: Install script for moving intake collections to the vault
   become_user: "{{ irods_service_account }}"
@@ -302,17 +317,26 @@
     job: '/bin/bash /var/lib/irods/.irods/cronjob-revision-cleanup.sh >> /var/lib/irods/log/cronjob-revision-cleanup.log 2>&1'
 
 
+- name: Ensure cronjob script for moving collections from intake to vault is installed
+  copy:
+    src: run-intake-movetovault.sh
+    dest: '/var/lib/irods/.irods/run-intake-movetovault.sh'
+    owner: '{{ irods_service_account }}'
+    group: '{{ irods_service_account }}'
+    mode: '0755'
+  when: enable_intake or yoda_environment in ["development","testing"]
+
+
 - name: Configure cronjob for moving collections from intake to vault
   become_user: "{{ irods_service_account }}"
   become: yes
+  # Name kept for historical reasons, so that the playbook updates old-style
+  # cronjobs that invoked the rule directly.
   cron:
     name: 'job_movetovault.r'
     minute: '*/5'
-    job: >
-      /bin/irule -r irods_rule_engine_plugin-irods_rule_language-instance -F
-      /var/lib/irods/.irods/job_movetovault.r >>$HOME/iRODS/server/log/job_movetovault.log 2>&1
-  # This script is provided by the test playbook for development/test servers.
-  when: enable_intake and yoda_environment not in ["development","testing"]
+    job: '/var/lib/irods/.irods/run-intake-movetovault.sh >& /dev/null'
+  when: enable_intake or yoda_environment in ["development","testing"]
 
 
 - name: Ensure that ExecCmd dir exists

--- a/roles/yoda_rulesets/templates/job_clearintakelocks.r.j2
+++ b/roles/yoda_rulesets/templates/job_clearintakelocks.r.j2
@@ -1,18 +1,18 @@
 # \file
 # \brief job
-# \author Ton Smeele
-# \copyright Copyright (c) 2015, Utrecht university. All rights reserved
+# \author Sietse Snel
+# \copyright Copyright (c) 2022, Utrecht university. All rights reserved
 # \license GPLv3, see LICENSE
 #
 #  This file should be executed as part of a recurring crontab job
 #  as the irods admin user (i.e. irods user type rodsadmin)
 #  e.g. run every 5 minutes
 #
-#  if another instance of the job is running then the vault will be
-#  locked and silently ignored
+#  It clears all locks on intake folders after job_movetovault has run, in
+#  order to facilitate retries after transient errors
 #
 
-uuYcRunIntake2Vault {
+uuYcClearIntakeLocks {
 	# intake areas can be added to the grouplist as needed
 	*grouplist = list ( {{ intake_groups | map("regex_replace","(.+)",'\"\\1\"') | join(',') }} );
 	*zone = $rodsZoneClient;
@@ -20,17 +20,10 @@ uuYcRunIntake2Vault {
 	foreach (*grp in *grouplist) {
 		*intakeRoot = "/*zone/home/grp-intake-*grp";
 		*vaultRoot  = "/*zone/home/grp-vault-*grp";
-		uuLock(*vaultRoot, *status);
-		if (*status == 0) {
-			# we have a lock
-			uuYc2Vault(*intakeRoot, *vaultRoot, *status);
-			if (*status == 0 ) then *result = "ok" else *result = "ERROR (*status)";
-			writeLine("serverLog","RunIntake2Vault for *intakeRoot result = *result");
-			uuUnlock(*vaultRoot);
-		}
+                # uuUnlock also succeeds if lock doesn't exist, so no need to verify that lock exists first
+		uuUnlock(*vaultRoot);
 	}
 }
-
 
 input *intakeRoot='dummy'
 output ruleExecOut

--- a/roles/yoda_test/files/job_clearintakelocks.r
+++ b/roles/yoda_test/files/job_clearintakelocks.r
@@ -1,0 +1,29 @@
+# \file
+# \brief job
+# \author Sietse Snel
+# \copyright Copyright (c) 2022, Utrecht university. All rights reserved
+# \license GPLv3, see LICENSE
+#
+#  This file should be executed as part of a recurring crontab job
+#  as the irods admin user (i.e. irods user type rodsadmin)
+#  e.g. run every 5 minutes
+#
+#  It clears all locks on intake folders after job_movetovault has run, in
+#  order to facilitate retries after transient errors
+#
+
+uuYcClearIntakeLocks {
+	# intake areas can be added to the grouplist as needed
+	*grouplist = list ("initial","test");
+	*zone = $rodsZoneClient;
+
+	foreach (*grp in *grouplist) {
+		*intakeRoot = "/*zone/home/grp-intake-*grp";
+		*vaultRoot  = "/*zone/home/grp-vault-*grp";
+                # uuUnlock also succeeds if lock doesn't exist, so no need to verify that lock exists first
+		uuUnlock(*vaultRoot);
+	}
+}
+
+input *intakeRoot='dummy'
+output ruleExecOut

--- a/roles/yoda_test/files/job_movetovault.r
+++ b/roles/yoda_test/files/job_movetovault.r
@@ -16,10 +16,6 @@ uuYcRunIntake2Vault {
                 *intakeRoot = "/*zone/home/grp-intake-*grp";
                 *vaultRoot  = "/*zone/home/grp-vault-*grp";
                 uuLock(*vaultRoot, *status);
-                # FIX ME: currently we ignore existing locks
-                # because locks are not removed when the rule exist with error
-                # need a more robust solution for this!
-                *status = 0;
                 if (*status == 0) {
                         # we have a lock
                         uuYc2Vault(*intakeRoot, *vaultRoot, *status);

--- a/roles/yoda_test/tasks/install-data.yml
+++ b/roles/yoda_test/tasks/install-data.yml
@@ -200,7 +200,7 @@
   ignore_errors: true
 
 
-- name: Ensure intake module cronjob rules are present
+- name: Ensure intake module rule files are present
   become_user: '{{ irods_service_account }}'
   become: yes
   copy:
@@ -210,15 +210,7 @@
   with_items:
     - 'job_movetovault.r'
     - 'job_checksums.r'
-
-
-- name: Configure cronjob to move grp-intake-* datapackages to the grp-vault-*
-  become_user: '{{ irods_service_account }}'
-  become: yes
-  cron:
-    name: 'job_movetovault.r'
-    minute: '*/5'
-    job: '/bin/irule -r irods_rule_engine_plugin-irods_rule_language-instance -F /var/lib/irods/.irods/job_movetovault.r >> /var/lib/irods/log/job_movetovault.log 2>&1'
+    - 'job_clearintakelocks.r'
 
 
 - name: Configure cronjob to make checksums of datapackages in grp-vault-*


### PR DESCRIPTION
This re-enables locking on intake module movetovault jobs, so that
at most one movetovault job runs at any given time for a particular intake
group and the jobs can't interfere. An additional mechanism for
clearing intake group folder locks in case a movetovault job is
interrupted due to a transient failure has also been added.

An increase in the lock timeouts in the main ruleset is also part
of the fix for the issue.

If accepted, please merge into release-1.7 and release-1.8 branches as well.