### PR TITLE
Fix YDA-4573: DavRODS setting not processed

### DIFF
--- a/roles/yoda_rulesets/defaults/main.yml
+++ b/roles/yoda_rulesets/defaults/main.yml
@@ -100,3 +100,10 @@ token_length: 32                                      # Length of data access to
 token_lifetime: 72                                    # Lifetime of data access tokens (in hours)
 
 yoda_portal_fqdn: PLACEHOLDER           # Yoda portal FQDN
+
+yoda_davrods_fqdn: data.yoda.test           # Yoda Davrods WebDAV fully qualified domain name (FQDN)
+yoda_davrods_port: 443
+
+yoda_davrods_anonymous_enabled: true
+yoda_davrods_anonymous_fqdn: public.data.yoda.test
+yoda_davrods_anonymous_port: 443


### PR DESCRIPTION
Add default values for DavRODS settings to the yoda_rulesets role, so
that the yoda_davrods_anonymous_fqdn value is copied to the /zoneName/yoda
AVU in case of default settings. This value is needed by the publication
logic.

If accepted, please merge into release-1.8 branch as well.