### PR TITLE
YDA-4769: implement RADIUS fallback for DAP

### DIFF
--- a/docs/administration/configuring-yoda.md
+++ b/docs/administration/configuring-yoda.md
@@ -288,6 +288,7 @@ token_database          | Location of the database that contain the tokens
 token_database_password | Token database password
 token_length            | Length of data access tokens
 token_lifetime          | Lifetime of data access tokens (in hours) (in hours)
+enable_radius_fallback  | Fall back on RADIUS authentication if token authentication fails (default: false). Only enables RADIUS fallback if `enable_tokens` is set to `true`.This is a legacy parameter that will be removed in a future version of Yoda.
 
 ### Public host configuration
 

--- a/roles/irods_icat/defaults/main.yml
+++ b/roles/irods_icat/defaults/main.yml
@@ -44,6 +44,7 @@ sqlcipher_dev:
 
 # PAM configuration.
 pam_fail_delay: 1000000                    # PAM fail delay in micro-seconds
+enable_radius_fallback: false
 pam_radius_config: |
   127.0.0.1     secret         1
   other-server  other-secret   3

--- a/roles/irods_icat/tasks/setup_pam.yml
+++ b/roles/irods_icat/tasks/setup_pam.yml
@@ -1,10 +1,26 @@
 ---
 # copyright Utrecht University
 
-- name: Ensure PAM radius is absent
+- name: Install pam_radius if needed for fallback
   ansible.builtin.package:
     name: pam_radius
+    state: '{{ "present" if enable_radius_fallback else "absent" }}'
+
+
+- name: Ensure /etc/pam_radius.conf is configured if needed for fallback
+  ansible.builtin.template:
+    src: 'pam_radius.conf.j2'
+    dest: '/etc/pam_radius.conf'
+    mode: '0600'
+  no_log: true
+  when: enable_radius_fallback
+
+
+- name: Ensure /etc/pam_radius.conf is removed if no fallback is configured
+  ansible.builtin.file:
+    path: /etc/pam_radius.conf
     state: absent
+  when: not enable_radius_fallback
 
 
 - name: Ensure external user check is present
@@ -91,12 +107,6 @@
     src: 'irods_pam.j2'
     dest: '/etc/pam.d/irods'
     mode: '0644'
-
-
-- name: Ensure deprecated /etc/pam_radius.conf is removed
-  ansible.builtin.file:
-    path: /etc/pam_radius.conf
-    state: absent
 
 
 - name: Ensure OIDC authentication is present

--- a/roles/irods_icat/templates/irods_pam.j2
+++ b/roles/irods_icat/templates/irods_pam.j2
@@ -8,7 +8,11 @@ auth        optional      pam_faildelay.so delay={{ pam_fail_delay }}
 auth        sufficient      pam_unix.so
 {% endif %}
 
-{% if enable_tokens %}
+{% if enable_tokens and enable_radius_fallback %}
+auth        [success=done auth_err=ignore] pam_python.so /usr/local/bin/token-auth.py
+
+auth        sufficient      pam_radius_auth.so
+{% elif enable_tokens %}
 auth        sufficient      pam_python.so /usr/local/bin/token-auth.py
 {% endif %}
 

--- a/roles/irods_icat/templates/pam_radius.conf.j2
+++ b/roles/irods_icat/templates/pam_radius.conf.j2
@@ -1,0 +1,35 @@
+# {{ ansible_managed }}
+#  pam_radius_auth configuration file.  Copy to: /etc/pam_radius.conf
+#
+#  For proper security, this file SHOULD have permissions 0600,
+#  that is readable by root, and NO ONE else.  If anyone other than
+#  root can read this file, then they can spoof responses from the server!
+#
+#  There are 3 fields per line in this file.  There may be multiple
+#  lines.  Blank lines or lines beginning with '#' are treated as
+#  comments, and are ignored.  The fields are:
+#
+#  server[:port] secret [timeout]
+#
+#  the port name or number is optional.  The default port name is
+#  "radius", and is looked up from /etc/services The timeout field is
+#  optional.  The default timeout is 3 seconds.
+#
+#  If multiple RADIUS server lines exist, they are tried in order.  The
+#  first server to return success or failure causes the module to return
+#  success or failure.  Only if a server fails to response is it skipped,
+#  and the next server in turn is used.
+#
+#  The timeout field controls how many seconds the module waits before
+#  deciding that the server has failed to respond.
+#
+# server[:port]    shared_secret      timeout (s)
+# 127.0.0.1        secret             1
+# other-server     other-secret       3
+
+{{ pam_radius_config }}
+
+#
+# having localhost in your radius configuration is a Good Thing.
+#
+# See the INSTALL file for pam.conf hints.


### PR DESCRIPTION
Implement temporary option to make DAP authentication fall
back to RADIUS authentication, so that users can use both
DAP and user/password authentication for WebDAV.