### PR TITLE
Permit Apache to listen on nonstandard ports

### DIFF
--- a/roles/yoda_davrods/tasks/main.yml
+++ b/roles/yoda_davrods/tasks/main.yml
@@ -152,6 +152,14 @@
   notify: Restart firewall
 
 
+- name: Allow Apache to listen to davrods port
+  community.general.seport:
+    ports: "{{ yoda_davrods_port }}"
+    proto: tcp
+    setype: http_port_t
+    state: present
+
+
 - name: Allow public to ports for anonymous davrods in firewall
   firewalld:
     port: '{{ yoda_davrods_anonymous_port }}/tcp'
@@ -159,6 +167,14 @@
     state: enabled
     immediate: true
   notify: Restart firewall
+
+
+- name: Allow Apache to listen to anonymous davrods port
+  community.general.seport:
+    ports: "{{ yoda_davrods_anonymous_port }}"
+    proto: tcp
+    setype: http_port_t
+    state: present
 
 
 - name: Ensure styling of davrods directory listing is present

--- a/roles/yoda_public/tasks/main.yml
+++ b/roles/yoda_public/tasks/main.yml
@@ -18,3 +18,11 @@
     state: enabled
     immediate: true
   notify: Restart firewall
+
+
+- name: Allow Apache to listen to Yoda public port
+  community.general.seport:
+    ports: "{{ yoda_public_port }}"
+    proto: tcp
+    setype: http_port_t
+    state: present


### PR DESCRIPTION
Permit Apache to listen on DavRODS and public port, if
a nonstandard port has been configured.