### PR TITLE
Make external users domain filter available in Python config.

### DIFF
--- a/environments/development/allinone/group_vars/allinone.yml
+++ b/environments/development/allinone/group_vars/allinone.yml
@@ -177,7 +177,7 @@ eus_smtp_security: false
 eus_smtp_from_address: yoda@yoda.test
 eus_smtp_replyto_address: yoda@yoda.test
 eus_mail_template: uu
-external_users_domain_filter: uu.nl     # Domains to filter, separated by |
+external_users_domain_filter: uu.nl | acc.uu.nl  # Domains to filter, separated by |
 
 # Openid Connect configuration (This configuration is for TESTING purposes!)
 oidc_active: true

--- a/environments/development/full/group_vars/full.yml
+++ b/environments/development/full/group_vars/full.yml
@@ -177,7 +177,7 @@ eus_smtp_security: false
 eus_smtp_from_address: yoda@yoda.test
 eus_smtp_replyto_address: yoda@yoda.test
 eus_mail_template: uu
-external_users_domain_filter: uu.nl     # Domains to filter, separated by |
+external_users_domain_filter: uu.nl | acc.uu.nl  # Domains to filter, separated by |
 
 # Openid Connect configuration (This configuration is for TESTING purposes!)
 oidc_active: true

--- a/environments/development/surf/group_vars/surf.yml
+++ b/environments/development/surf/group_vars/surf.yml
@@ -177,7 +177,7 @@ eus_smtp_security: false
 eus_smtp_from_address: yoda@surfyoda.test
 eus_smtp_replyto_address: yoda@surfyoda.test
 eus_mail_template: uu
-external_users_domain_filter: uu.nl     # Domains to filter, separated by |
+external_users_domain_filter: uu.nl | acc.uu.nl  # Domains to filter, separated by |
 
 # Openid Connect configuration (This configuration is for TESTING purposes!)
 oidc_active: true

--- a/roles/irods_icat/defaults/main.yml
+++ b/roles/irods_icat/defaults/main.yml
@@ -51,7 +51,7 @@ pam_radius_config: |
 
 # External Users configuration
 external_users: true
-external_users_domain_filter: uu.nl
+external_users_domain_filter: uu.nl | acc.uu.nl  # Domains to filter, separated by |
 eus_api_fqdn: eus.yoda.test
 eus_api_port: 8443
 eus_api_secret: PLACEHOLDER

--- a/roles/irods_icat/defaults/main.yml
+++ b/roles/irods_icat/defaults/main.yml
@@ -52,6 +52,7 @@ pam_radius_config: |
 # External Users configuration
 external_users: true
 external_users_domain_filter: uu.nl | acc.uu.nl  # Domains to filter, separated by |
+external_users_exact_match: false                # Controls whether the external user domains should match exactly
 eus_api_fqdn: eus.yoda.test
 eus_api_port: 8443
 eus_api_secret: PLACEHOLDER

--- a/roles/irods_icat/templates/is-user-external.sh.j2
+++ b/roles/irods_icat/templates/is-user-external.sh.j2
@@ -2,7 +2,7 @@
 # {{ ansible_managed }}
 
 {% if external_users_domain_filter  %}
-[[ "$PAM_USER" =~ .*@.* ]] && [[ ! "$PAM_USER" =~ [.@]({{external_users_domain_filter | replace('.', '\.')}})$ ]]
+[[ "$PAM_USER" =~ .*@.* ]] && [[ ! "$PAM_USER" =~ [.@]({{external_users_domain_filter | replace (' ','') | replace('.', '\.')}})$ ]]
 {% else %}
 [[ "$PAM_USER" =~ .*@.* ]]
 {% endif %}

--- a/roles/irods_icat/templates/is-user-external.sh.j2
+++ b/roles/irods_icat/templates/is-user-external.sh.j2
@@ -1,7 +1,9 @@
 #!/bin/bash
 # {{ ansible_managed }}
 
-{% if external_users_domain_filter  %}
+{% if external_users_domain_filter and external_users_exact_match %}
+[[ "$PAM_USER" =~ .*@.* ]] && [[ ! "$PAM_USER" =~ ^[A-Za-z0-9._%+-]+@({{external_users_domain_filter | replace (' ','') | replace('.', '\.')}})$ ]]
+{% elif external_users_domain_filter %}
 [[ "$PAM_USER" =~ .*@.* ]] && [[ ! "$PAM_USER" =~ [.@]({{external_users_domain_filter | replace (' ','') | replace('.', '\.')}})$ ]]
 {% else %}
 [[ "$PAM_USER" =~ .*@.* ]]

--- a/roles/yoda_rulesets/defaults/main.yml
+++ b/roles/yoda_rulesets/defaults/main.yml
@@ -117,3 +117,7 @@ yoda_davrods_port: 443
 yoda_davrods_anonymous_enabled: true
 yoda_davrods_anonymous_fqdn: public.data.yoda.test
 yoda_davrods_anonymous_port: 443
+
+# External Users configuration
+external_users: true
+external_users_domain_filter: uu.nl | acc.uu.nl  # Domains to filter, separated by |

--- a/roles/yoda_rulesets/templates/rules_uu.cfg.j2
+++ b/roles/yoda_rulesets/templates/rules_uu.cfg.j2
@@ -65,5 +65,5 @@ enable_tape_archive            = '{{ ["false", "true"][enable_tape_archive|int] 
 temporary_files                = '{{ temporary_files | join (" ") }}'
 
 {% if external_users %}
-external_users_domain_filter   = '{{ external_users_domain_filter | replace('|', '')}}'
+external_users_domain_filter   = '{{ external_users_domain_filter | replace (' ','') | replace('|', ' ')}}'
 {% endif %}

--- a/roles/yoda_rulesets/templates/rules_uu.cfg.j2
+++ b/roles/yoda_rulesets/templates/rules_uu.cfg.j2
@@ -63,3 +63,7 @@ token_lifetime                 = '{{ token_lifetime }}'
 enable_tape_archive            = '{{ ["false", "true"][enable_tape_archive|int] }}'
 
 temporary_files                = '{{ temporary_files | join (" ") }}'
+
+{% if external_users %}
+external_users_domain_filter   = '{{ external_users_domain_filter | replace('|', '')}}'
+{% endif %}


### PR DESCRIPTION
Fixes https://github.com/UtrechtUniversity/yoda/issues/87