### PR TITLE
YDA-4796: handle unavailable DAP token DB

### DIFF
--- a/roles/irods_icat/templates/token-auth.py.j2
+++ b/roles/irods_icat/templates/token-auth.py.j2
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # {{ ansible_managed }}
 
+import os
 from datetime import datetime
 from traceback import print_exc
 
@@ -17,6 +18,11 @@ def pam_sm_authenticate(pamh, flags, argv):
 
     token = pamh.authtok
     if token is None:
+        return pamh.PAM_AUTH_ERR
+
+    # This ensures that the authentication script does not create 0 byte
+    # token databases, which can interfere with running the Ansible playbook.
+    if not os.path.isfile(TOKEN_DB):
         return pamh.PAM_AUTH_ERR
 
     authenticated = False


### PR DESCRIPTION
Return error code if token database is not (yet) available, to prevent PAM auth script from creating 0 byte token databases that interfere with playbook.