### PR TITLE
YDA-4856: fix URLs in notifications

### DIFF
--- a/roles/yoda_rulesets/templates/rules_uu.cfg.j2
+++ b/roles/yoda_rulesets/templates/rules_uu.cfg.j2
@@ -38,9 +38,7 @@ enable_deposit                 = '{{ ["false", "true"][enable_deposit|int] }}'
 enable_open_search             = '{{ ["false", "true"][enable_open_search|int] }}'
 enable_intake                  = '{{ ["false", "true"][enable_intake|int] }}'
 enable_datarequest             = '{{ ["false", "true"][enable_datarequest|int] }}'
-{% if enable_datarequest %}
 yoda_portal_fqdn               = '{{ yoda_portal_fqdn }}'
-{% endif %}
 
 epic_pid_enabled               = '{{ ["false", "true"][epic_pid_enabled|int] }}'
 {% if epic_pid_enabled %}


### PR DESCRIPTION
We need to always set the yoda_portal_fqdn parameter in the ruleset configuration, not just when the DR module is enabled. Otherwise notification messages will get wrong URLs for portal links when DR module is disabled.