### PR TITLE
Ansible lint 6.8 fixes

### DIFF
--- a/roles/apache/tasks/main.yml
+++ b/roles/apache/tasks/main.yml
@@ -12,7 +12,7 @@
 
 
 - name: Allow public to ports for Apache in firewall
-  firewalld:
+  ansible.posix.firewalld:
     port: '{{ item }}'
     permanent: true
     state: enabled

--- a/roles/composable_resources/tasks/main.yml
+++ b/roles/composable_resources/tasks/main.yml
@@ -4,6 +4,7 @@
 - name: Ensure all resources exist
   become_user: irods
   become: true
+  # noqa fqcn[action]
   irods_resource:
     name: "{{ item.name }}"
     resource_type: "{{ item.resource_type }}"
@@ -17,6 +18,7 @@
 - name: Ensure iRODS default resource is set in irods_environment.json
   become_user: '{{ irods_service_account }}'
   become: true
+  # noqa fqcn[action]
   irods_config:
     path: '/var/lib/irods/.irods/irods_environment.json'
     key: 'irods_default_resource'
@@ -26,6 +28,7 @@
 - name: Ensure iRODS default resource is set in server_config.json
   become_user: '{{ irods_service_account }}'
   become: true
+  # noqa fqcn[action]
   irods_config:
     path: '/etc/irods/server_config.json'
     key: 'default_resource_name'

--- a/roles/dms_archive_mock/tasks/main.yml
+++ b/roles/dms_archive_mock/tasks/main.yml
@@ -32,6 +32,7 @@
 - name: Ensure mock tape archive resource exist
   become_user: "{{ irods_service_account }}"
   become: true
+  # noqa fqcn[action]
   irods_resource:
     name: "mockTapeArchive"
     resource_type: "unixfilesystem"

--- a/roles/irods_database/tasks/main.yml
+++ b/roles/irods_database/tasks/main.yml
@@ -12,7 +12,7 @@
 - name: Create iCAT database
   become_user: postgres
   become: true
-  postgresql_db:
+  community.postgresql.postgresql_db:
     name: "{{ irods_database_name }}"
     encoding: UTF-8
     lc_collate: en_US.UTF-8
@@ -23,7 +23,7 @@
 - name: Create iRODS database user
   become_user: postgres
   become: true
-  postgresql_user:
+  community.postgresql.postgresql_user:
     db: "{{ irods_database_name }}"
     name: "{{ irods_database_user }}"
     password: "{{ irods_database_password }}"

--- a/roles/irods_database/tasks/password_protect.yml
+++ b/roles/irods_database/tasks/password_protect.yml
@@ -2,6 +2,7 @@
 # copyright Utrecht University
 
 - name: Resolve iCAT host
+  # noqa fqcn[action]
   resolve:
     host: "{{ icat_host }}"
   register: icat_resolved

--- a/roles/irods_icat/tasks/main.yml
+++ b/roles/irods_icat/tasks/main.yml
@@ -200,6 +200,7 @@
 - name: Ensure iCAT host is defined
   become_user: '{{ irods_service_account }}'
   become: true
+  # noqa fqcn[action]
   irods_config:
     path: '/etc/irods/server_config.json'
     key: 'icat_host'
@@ -209,6 +210,7 @@
 - name: Ensure iRODS host is defined
   become_user: '{{ irods_service_account }}'
   become: true
+  # noqa fqcn[action]
   irods_config:
     path: '/var/lib/irods/.irods/irods_environment.json'
     key: 'irods_host'
@@ -218,6 +220,7 @@
 - name: Set delayed rule sleep time to 10 seconds
   become_user: '{{ irods_service_account }}'
   become: true
+  # noqa fqcn[action]
   irods_advanced:
     path: '/etc/irods/server_config.json'
     key: 'rule_engine_server_sleep_time_in_seconds'
@@ -281,6 +284,7 @@
 - name: Ensure Python plugin is configured
   become_user: '{{ irods_service_account }}'
   become: true
+  # noqa fqcn[action]
   irods_python:
     config_path: '/etc/irods/server_config.json'
   when: not ansible_check_mode
@@ -289,6 +293,7 @@
 - name: Ensure indexing plugin is configured
   become_user: '{{ irods_service_account }}'
   become: true
+  # noqa fqcn[action]
   irods_indexing:
     config_path: '/etc/irods/server_config.json'
     index_server: '{{ opensearch_server }}'
@@ -313,7 +318,7 @@
 
 
 - name: Enable ports for iCAT in firewall
-  firewalld:
+  ansible.posix.firewalld:
     port: '{{ item }}'
     permanent: true
     state: enabled
@@ -375,6 +380,7 @@
 - name: Ensure iRODS is configured to use SSL
   become_user: '{{ irods_service_account }}'
   become: true
+  # noqa fqcn[action]
   irods_config:
     path: '/var/lib/irods/.irods/irods_environment.json'
     key: '{{ item.key }}'
@@ -428,7 +434,7 @@
 
 
 - name: Ensure iRODS is configured to use SSL connection to database
-  ini_file:
+  community.general.ini_file:
     path: /var/lib/irods/.odbc.ini
     section: postgres
     option: 'sslmode'
@@ -469,6 +475,7 @@
 - name: Ensure Yoda anonymous user exists
   become_user: '{{ irods_service_account }}'
   become: true
+  # noqa fqcn[action]
   irods_mkuser:
     name: anonymous
   when: not ansible_check_mode

--- a/roles/irods_resource/tasks/main.yml
+++ b/roles/irods_resource/tasks/main.yml
@@ -232,13 +232,14 @@
 - name: Ensure Python plugin is configured
   become_user: '{{ irods_service_account }}'
   become: true
+  # noqa fqcn[action]
   irods_python:
     config_path: '/etc/irods/server_config.json'
   when: not ansible_check_mode
 
 
 - name: Enable ports for resource in firewall
-  firewalld:
+  ansible.posix.firewalld:
     port: '{{ item }}'
     permanent: true
     state: enabled
@@ -300,6 +301,7 @@
 - name: Ensure iRODS is configured to use SSL
   become_user: '{{ irods_service_account }}'
   become: true
+  # noqa fqcn[action]
   irods_config:
     path: '/var/lib/irods/.irods/irods_environment.json'
     key: '{{ item.key }}'
@@ -320,6 +322,7 @@
 - name: Ensure iRODS server keys are synced
   become_user: '{{ irods_service_account }}'
   become: true
+  # noqa fqcn[action]
   irods_config:
     path: '/etc/irods/server_config.json'
     key: '{{ item.key }}'

--- a/roles/irods_rodsadmin/tasks/main.yml
+++ b/roles/irods_rodsadmin/tasks/main.yml
@@ -16,6 +16,7 @@
 - name: Ensure additional rods admin iRODS users are present
   become_user: '{{ irods_service_account }}'
   become: true
+  # noqa fqcn[action]
   irods_mkuser:
     name: "{{ item }}"
     type: rodsadmin

--- a/roles/mailpit/tasks/main.yml
+++ b/roles/mailpit/tasks/main.yml
@@ -43,7 +43,7 @@
 
 
 - name: Allow public access to mailpit web interface
-  firewalld:
+  ansible.posix.firewalld:
     port: '8025/tcp'
     permanent: true
     state: enabled

--- a/roles/opensearch/tasks/main.yml
+++ b/roles/opensearch/tasks/main.yml
@@ -61,7 +61,7 @@
 
 
 - name: Set vm.max_map_count in sysctl.conf
-  sysctl:
+  ansible.posix.sysctl:
     name: vm.max_map_count
     value: '262144'
     state: present
@@ -82,7 +82,7 @@
 
 
 - name: Enable port for indexing
-  firewalld:
+  ansible.posix.firewalld:
     port: 9200/tcp
     permanent: true
     state: enabled

--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -31,7 +31,7 @@
 
 
 - name: Allow PHP to open TCP sockets in SELinux config
-  seboolean:
+  ansible.posix.seboolean:
     name: httpd_can_network_connect
     state: true
     persistent: true

--- a/roles/postfix/tasks/main.yml
+++ b/roles/postfix/tasks/main.yml
@@ -12,7 +12,7 @@
 
 
 - name: "Configure Postfix"
-  ini_file:
+  community.general.ini_file:
     path: /etc/postfix/main.cf
     section:
     option: "{{ item.key }}"
@@ -34,7 +34,7 @@
 
 
 - name: "Configure Postfix SASL for SMTP delivery via TLS"
-  ini_file:
+  community.general.ini_file:
     section:
     path: /etc/postfix/main.cf
     option: "{{ item.key }}"
@@ -55,7 +55,7 @@
 
 
 - name: "Configure Postfix debugging parameters"
-  ini_file:
+  community.general.ini_file:
     path: /etc/postfix/main.cf
     section:
     option: "{{ item.key }}"

--- a/roles/postgresql/tasks/main.yml
+++ b/roles/postgresql/tasks/main.yml
@@ -32,7 +32,7 @@
 
 
 - name: Allow access to port 5432 in firewall
-  firewalld:
+  ansible.posix.firewalld:
     port: 5432/tcp
     permanent: true
     state: enabled

--- a/roles/yoda_davrods/tasks/main.yml
+++ b/roles/yoda_davrods/tasks/main.yml
@@ -39,7 +39,7 @@
 
 
 - name: Allow Apache to execute davrods module
-  sefcontext:
+  community.general.sefcontext:
     target: /etc/httpd/modules/mod_davrods.so
     setype: httpd_sys_script_exec_t
     state: present
@@ -55,7 +55,7 @@
 
 
 - name: Allow DavRODS connections to iCAT server
-  seboolean:
+  ansible.posix.seboolean:
     name: httpd_can_network_connect
     state: true
     persistent: true
@@ -120,7 +120,7 @@
 
 
 - name: Allow Apache to execute iRODS network plugins
-  sefcontext:
+  community.general.sefcontext:
     target: '{{ item }}'
     setype: httpd_sys_script_exec_t
     state: present
@@ -144,7 +144,7 @@
 
 
 - name: Allow public to ports for davrods in firewall
-  firewalld:
+  ansible.posix.firewalld:
     port: '{{ yoda_davrods_port }}/tcp'
     permanent: true
     state: enabled
@@ -161,7 +161,7 @@
 
 
 - name: Allow public to ports for anonymous davrods in firewall
-  firewalld:
+  ansible.posix.firewalld:
     port: '{{ yoda_davrods_anonymous_port }}/tcp'
     permanent: true
     state: enabled

--- a/roles/yoda_external_user_service/tasks/main.yml
+++ b/roles/yoda_external_user_service/tasks/main.yml
@@ -47,7 +47,7 @@
 
 
 - name: Allow public to API port for External User Service in firewall
-  firewalld:
+  ansible.posix.firewalld:
     port: '8443/tcp'
     permanent: true
     state: enabled
@@ -58,7 +58,7 @@
 - name: Create Yoda External User Service database
   become_user: postgres
   become: true
-  postgresql_db:
+  community.postgresql.postgresql_db:
     name: "{{ eus_db_name }}"
     encoding: UTF-8
     lc_collate: en_US.UTF-8
@@ -69,7 +69,7 @@
 - name: Create Yoda External User Service database user
   become_user: postgres
   become: true
-  postgresql_user:
+  community.postgresql.postgresql_user:
     db: "{{ eus_db_name }}"
     name: "{{ eus_db_user }}"
     password: "{{ eus_db_password }}"
@@ -96,7 +96,7 @@
 - name: Make sure database user has permissions on tables
   become_user: postgres
   become: true
-  postgresql_privs:
+  community.postgresql.postgresql_privs:
     database: "{{ eus_db_name }}"
     state: present
     privs: SELECT,INSERT,UPDATE,DELETE
@@ -113,7 +113,7 @@
 - name: Make sure database user has permissions on sequences
   become_user: postgres
   become: true
-  postgresql_privs:
+  community.postgresql.postgresql_privs:
     database: "{{ eus_db_name }}"
     state: present
     privs: USAGE

--- a/roles/yoda_landingpages/tasks/main.yml
+++ b/roles/yoda_landingpages/tasks/main.yml
@@ -16,7 +16,7 @@
 
 
 - name: Add upload user pub key to authorized_keys of inbox
-  authorized_key:
+  ansible.posix.authorized_key:
     user: '{{ yoda_inbox_user }}'
     key: '{{ upload_pub_key | b64decode }}'
     state: present

--- a/roles/yoda_moai/tasks/main.yml
+++ b/roles/yoda_moai/tasks/main.yml
@@ -68,7 +68,7 @@
 
 
 - name: Add upload user pub key to authorized_keys of inbox
-  authorized_key:
+  ansible.posix.authorized_key:
     user: '{{ yoda_inbox_user }}'
     key: '{{ upload_pub_key | b64decode }}'
     state: present
@@ -112,7 +112,7 @@
 
 
 - name: Set SELinux context for shared libraries
-  sefcontext:
+  community.general.sefcontext:
     target: '{{ yoda_moai_home }}/yoda-moai/venv/.*\.so(\..*)?'
     setype: httpd_sys_script_exec_t
     state: present
@@ -126,7 +126,7 @@
 
 
 - name: Set SELinux context for Yoda MOAI database
-  sefcontext:
+  community.general.sefcontext:
     target: '{{ yoda_moai_home }}/moai.db'
     setype: httpd_sys_rw_content_t
     state: present

--- a/roles/yoda_portal/tasks/main.yml
+++ b/roles/yoda_portal/tasks/main.yml
@@ -134,7 +134,7 @@
 
 
 - name: Set SELinux context for shared libraries
-  sefcontext:
+  community.general.sefcontext:
     target: '/var/www/yoda/venv/.*\.so(\..*)?'
     setype: httpd_sys_script_exec_t
     state: present
@@ -148,7 +148,7 @@
 
 
 - name: Allow Flask to connect to OpenSearch
-  seboolean:
+  ansible.posix.seboolean:
     name: httpd_can_network_connect
     state: true
     persistent: true

--- a/roles/yoda_public/tasks/main.yml
+++ b/roles/yoda_public/tasks/main.yml
@@ -12,7 +12,7 @@
 
 
 - name: Allow public to port for Yoda Public in firewall
-  firewalld:
+  ansible.posix.firewalld:
     port: '{{ yoda_public_port }}/tcp'
     permanent: true
     state: enabled

--- a/roles/yoda_rulesets/tasks/main.yml
+++ b/roles/yoda_rulesets/tasks/main.yml
@@ -45,7 +45,7 @@
 - name: Sync rulesets with repos before applying patches
   become_user: "{{ irods_service_account }}"
   become: true
-  synchronize:
+  ansible.posix.synchronize:
     src: "/etc/irods/repo_{{ item.name }}/"
     dest: "/etc/irods/{{ item.name }}"
     checksum: true
@@ -89,7 +89,7 @@
 - name: Run make install for each ruleset
   become_user: "{{ irods_service_account }}"
   become: true
-  make:
+  community.general.make:
     chdir: "/etc/irods/{{ item.0.name }}"
     target: install
   when: item.1.changed or ( 'repo' in item.0 and 'patch' in item.0 )
@@ -110,6 +110,7 @@
 - name: Ensure all rulesets are in server config
   become_user: "{{ irods_service_account }}"
   become: true
+  # noqa fqcn[action]
   irods_rulesets:
     config_path: "/etc/irods/server_config.json"
     rulesets: "{{ (extra_rulesets + core_rulesets) | map(attribute='ruleset_name') | list }}"

--- a/roles/yoda_rulesets/tasks/yoda-ruleset.yml
+++ b/roles/yoda_rulesets/tasks/yoda-ruleset.yml
@@ -357,6 +357,7 @@
 - name: Set configuration AVUs for research ruleset to system collection
   become_user: "{{ irods_service_account }}"
   become: true
+  # noqa fqcn[action]
   irods_setavu:
     name: "/{{ irods_zone }}/yoda"
     irods_type: Collection
@@ -387,6 +388,7 @@
 - name: Set configuration AVUs for anonymous davrods vhosts
   become_user: "{{ irods_service_account }}"
   become: true
+  # noqa fqcn[action]
   irods_setavu:
     name: "/{{ irods_zone }}/yoda"
     irods_type: Collection

--- a/roles/yoda_zabbix_database/tasks/main.yml
+++ b/roles/yoda_zabbix_database/tasks/main.yml
@@ -34,7 +34,7 @@
 - name: Create Zabbix database user
   become_user: postgres
   become: true
-  postgresql_user:
+  community.postgresql.postgresql_user:
     db: "{{ zabbix_database_name }}"
     name: "{{ zabbix_database_user }}"
     priv: "CONNECT"

--- a/roles/yoda_zabbix_system/tasks/main.yml
+++ b/roles/yoda_zabbix_system/tasks/main.yml
@@ -61,14 +61,14 @@
 
 
 - name: Allow Zabbix agent to start
-  selinux_permissive:
+  community.general.selinux_permissive:
     name: zabbix_agent_t
     permissive: true
   when: ansible_selinux.status == "enabled"
 
 
 - name: Allow Zabbix agent to sudo
-  seboolean:
+  ansible.posix.seboolean:
     name: zabbix_run_sudo
     state: true
     persistent: true

--- a/zabbix.yml
+++ b/zabbix.yml
@@ -2,7 +2,8 @@
 # copyright Utrecht University
 # This playbook provisions Yoda instance with the Zabbix agent, PostgreSQL monitoring and Zabbix user access to the database.
 
-- hosts: localhost
+- name: Check Ansible version
+  hosts: localhost
   gather_facts: false
   pre_tasks:
     - name: Verify Ansible version meets requirements
@@ -12,7 +13,8 @@
           "You must update Ansible to at least 2.9 to deploy Yoda."
 
 
-- hosts: all
+- name: Check repository branches
+  hosts: all
   pre_tasks:
     - name: Retrieve Yoda repository branch
       ansible.builtin.shell: |


### PR DESCRIPTION
This fixes lint warnings with ansible-lint 6.8.x, and adds noqa flags to actions that use internal modules. 