### PR TITLE
YDA-4969: ensure that hosts file has host FQDN

### DIFF
--- a/roles/common/tasks/hostname.yml
+++ b/roles/common/tasks/hostname.yml
@@ -1,12 +1,30 @@
 ---
 # copyright Utrecht University
 
-- name: Read the current hostname configured in /etc/hosts
+- name: Read the current hostname
   ansible.builtin.command: 'hostname --fqdn'
   register: hostname
   changed_when: hostname.stdout.find(inventory_hostname) == -1
 
 
-- name: Ensure FQDN is defined as hostname in /etc/hosts
+- name: Ensure FQDN is defined as hostname
   ansible.builtin.command: hostnamectl set-hostname {{ inventory_hostname }}
   changed_when: hostname.stdout.find(inventory_hostname) == -1
+
+
+- name: Check whether /etc/hosts has FQDN entry
+  ansible.builtin.command:
+    cmd: grep -Fq "{{ inventory_hostname }}" /etc/hosts
+  register: check_etchosts
+  check_mode: false
+  ignore_errors: true
+  changed_when: false
+  when: yoda_environment != "development"
+
+
+- name: Add FQDN entry to /etc/hosts
+  ansible.builtin.lineinfile:
+    dest: /etc/hosts
+    line: '127.0.0.1 {{ inventory_hostname }} # Added by Yoda Ansible playbook'
+    state: present
+  when: yoda_environment != "development" and check_etchosts.rc == 1


### PR DESCRIPTION
Ensure that the /etc/hosts file has an entry for the FQDN (via the inventory hostname) of the current host. This ensures that iRODS works out of the box, without server admins having to manually edit the hosts file before deploying Yoda.