### PR TITLE
YDA-5024: fix deployment with DAP disabled

### DIFF
--- a/roles/irods_icat/defaults/main.yml
+++ b/roles/irods_icat/defaults/main.yml
@@ -27,21 +27,6 @@ irods_rum_job_enabled: true
 irods_rum_job_hour: 20
 irods_rum_job_minute: 0
 
-rpm_dest_dir: /tmp
-
-# sqlcipher RPM locations and checksum
-sqlcipher:
-  package: sqlcipher-4.5.1-0
-  url: https://github.com/UtrechtUniversity/sqlcipher/releases/download/v4.5.1/
-  filename: sqlcipher-4.5.1-0.el7.x86_64.rpm
-  checksum: sha256:b256727666088dbb34dee1fbb0673b6fed02547e8e140c1022f864c82973e829
-
-sqlcipher_dev:
-  package: sqlcipher-devel-4.5.1-0
-  url: https://github.com/UtrechtUniversity/sqlcipher/releases/download/v4.5.1/
-  filename: sqlcipher-devel-4.5.1-0.el7.x86_64.rpm
-  checksum: sha256:2bf78f64075a5c39c36055d338b4e89d49a5b3e0f0d6d6a210abce669405a31e
-
 # PAM configuration.
 pam_fail_delay: 1000000                    # PAM fail delay in micro-seconds
 enable_radius_fallback: false

--- a/roles/irods_icat/tasks/setup_pam.yml
+++ b/roles/irods_icat/tasks/setup_pam.yml
@@ -44,49 +44,10 @@
   when: external_users
 
 
-- name: Download sqlcipher rpms
-  ansible.builtin.get_url:
-    url: '{{ item.url }}/{{ item.filename }}'
-    dest: '{{ rpm_dest_dir }}/{{ item.filename }}'
-    checksum: '{{ item.checksum }}'
-    mode: 0644
-  with_items:
-    - {'url': '{{ sqlcipher.url }}', 'filename': '{{ sqlcipher.filename }}', 'checksum': '{{ sqlcipher.checksum }}'}
-    - {'url': '{{ sqlcipher_dev.url }}', 'filename': '{{ sqlcipher_dev.filename }}', 'checksum': '{{ sqlcipher_dev.checksum }}'}
-  when: enable_tokens
-
-
-- name: Install sqlcipher from downloaded rpms
-  ansible.builtin.package:
-    name: '{{ rpm_dest_dir }}/{{ item }}'
-    state: present
-  with_items:
-    - '{{ sqlcipher.filename }}'
-    - '{{ sqlcipher_dev.filename }}'
-  when: enable_tokens and not ansible_check_mode
-
-
 - name: Ensure Python dependencies are installed
   ansible.builtin.package:
     name:
       - python-pip
-    state: present
-  when: enable_tokens
-
-
-# Installation of pysqlcipher3 package fails silently if
-# GCC is unavailable, so we need to ensure it has been installed.
-- name: Ensure GCC is installed
-  ansible.builtin.package:
-    name: gcc
-    state: present
-  when: enable_tokens
-
-
-- name: Ensure pysqlcipher3 is installed
-  ansible.builtin.pip:
-    name:
-      - pysqlcipher3==1.0.4
     state: present
   when: enable_tokens
 

--- a/roles/yoda_rulesets/defaults/main.yml
+++ b/roles/yoda_rulesets/defaults/main.yml
@@ -36,6 +36,21 @@ irods_repl_resc:                 # List of replication resources
   - irodsRescRepl
 irods_resc_trigger_pol: []
 
+# sqlcipher RPM locations and checksum
+sqlcipher:
+  package: sqlcipher-4.5.1-0
+  url: https://github.com/UtrechtUniversity/sqlcipher/releases/download/v4.5.1/
+  filename: sqlcipher-4.5.1-0.el7.x86_64.rpm
+  checksum: sha256:b256727666088dbb34dee1fbb0673b6fed02547e8e140c1022f864c82973e829
+
+sqlcipher_dev:
+  package: sqlcipher-devel-4.5.1-0
+  url: https://github.com/UtrechtUniversity/sqlcipher/releases/download/v4.5.1/
+  filename: sqlcipher-devel-4.5.1-0.el7.x86_64.rpm
+  checksum: sha256:2bf78f64075a5c39c36055d338b4e89d49a5b3e0f0d6d6a210abce669405a31e
+
+rpm_dest_dir: /tmp
+
 # SURF config: separate resources for research and vault
 resource_research: "{{ irods_default_resc }}"
 resource_vault: "{{ irods_default_resc }}"

--- a/roles/yoda_rulesets/tasks/main.yml
+++ b/roles/yoda_rulesets/tasks/main.yml
@@ -1,11 +1,34 @@
 ---
 # copyright Utrecht University
 
+# GCC is needed to install pysqlcipher3 for yoda-ruleset
 - name: Ensure Python dependencies are installed
   ansible.builtin.package:
     name:
       - python-pip
+      - gcc
     state: present
+
+
+- name: Download sqlcipher rpms
+  ansible.builtin.get_url:
+    url: '{{ item.url }}/{{ item.filename }}'
+    dest: '{{ rpm_dest_dir }}/{{ item.filename }}'
+    checksum: '{{ item.checksum }}'
+    mode: 0644
+  with_items:
+    - {'url': '{{ sqlcipher.url }}', 'filename': '{{ sqlcipher.filename }}', 'checksum': '{{ sqlcipher.checksum }}'}
+    - {'url': '{{ sqlcipher_dev.url }}', 'filename': '{{ sqlcipher_dev.filename }}', 'checksum': '{{ sqlcipher_dev.checksum }}'}
+
+
+- name: Install sqlcipher from downloaded rpms
+  ansible.builtin.package:
+    name: '{{ rpm_dest_dir }}/{{ item }}'
+    state: present
+  with_items:
+    - '{{ sqlcipher.filename }}'
+    - '{{ sqlcipher_dev.filename }}'
+  when: not ansible_check_mode
 
 
 - name: Sanity check ruleset names


### PR DESCRIPTION
Move pysqlcipher3 to the ruleset requirements (in yoda-ruleset repository) and move its dependencies to the Yoda ruleset role. Pysqlcipher3 is also imported when data access tokens are disabled, so we need to always install it along with its dependencies.