### PR TITLE
Use irods_admins dict key

### DIFF
--- a/roles/irods_rodsadmin/tasks/main.yml
+++ b/roles/irods_rodsadmin/tasks/main.yml
@@ -9,7 +9,7 @@
     # https://github.com/ansible/ansible/issues/24425
     password: "{{ '%s' | format(irods_admins[item].password) | password_hash('sha512') }}"
     update_password: on_create
-  with_items: '{{ irods_admins.keys() | default([]) }}'
+  with_items: '{{ irods_admins | default([]) }}'
   when: irods_admins is defined
 
 
@@ -20,5 +20,5 @@
   irods_mkuser:
     name: "{{ item }}"
     type: rodsadmin
-  with_items: '{{ irods_admins.keys() | default([]) }}'
+  with_items: '{{ irods_admins | default([]) }}'
   when: irods_admins is defined


### PR DESCRIPTION
Fixes the error: 'dict object' has no attribute \"dict_keys(['*******'])\"\n\nThe error appears to be in '.../irods_rodsamin/tasks/main.yml'.

Please, confirm that this change does not mess with the current usage of the variable irods_admins in your tests.