### PR TITLE
YDA-4818: add Postfix canonical map setting

### DIFF
--- a/docs/administration/configuring-yoda.md
+++ b/docs/administration/configuring-yoda.md
@@ -282,13 +282,14 @@ Variable                     | Description
 enable_postfix               | Whether to enable the Postfix local MTA (default: false)
 postfix_myhostname           | Hostname of server where Postfix will be installed (compulsory parameter if Postfix is enabled)
 postfix_relayhost            | Relay host, the server that Postfix should send emails to (compulsory parameter if Postfix is enabled)
-postfix_relayhost_port:      | Port of relay host (default: 587)
+postfix_relayhost_port       | Port of relay host (default: 587)
 postfix_relayhost_username   | User name for authentication on relay host (compulsory parameter if Postfix is enabled)
 postfix_relayhost_password   | Password for authentication on relay host (compulsory parameter if Postfix is enabled)
 postfix_smtp_enable_tls      | Whether to enable TLS on connections to relay host. This also enables authentication on connections to the relay host (default: true)
 postfix_enable_debugging     | This enables additional logging on connections to the relay host. Useful for troubleshooting. (default: false)
 postfix_myorigin             | Sets origin domain for emails sent on the system. Defaults to the postfix_myhostname domain.
 postfix_inet_protocols       | Refers to Postfix inet_protocols setting. Can be useful for running Postfix in IPv4 only mode, if no IPv6 connectivity is available (default: "all")
+postfix_canonical_map        | An optional dictionary of rewrite rules for email addresses. See [the local Postfix MTA page](local-postfix-mta.md) for further information.
 
 ### DataCite Configuration
 

--- a/docs/administration/local-postfix-mta.md
+++ b/docs/administration/local-postfix-mta.md
@@ -29,15 +29,18 @@ email server are:
 * Postfix has proper logging of email message delivery, whereas Yoda and the EUS have very limited email logging
   in the default configuration. Complete logging makes it possible to verify that emails have been sent, and
   to find the cause of any problems in case something has gone wrong.
+* Postfix can be configured to rewrite internal email addresses to public email addresses, making it possible
+  to deliver email for Yoda accounts with nonexistent email addresses.
 
 In summary, using Postfix as a local MTA makes email delivery more resilient and helps with troubleshooting.
 
 ## Configuration
 
-Configuration consists of three parts:
+Configuration consists of up to four parts:
 * Configure Postfix
 * Configure the EUS to send emails to the Postfix instance
 * Configure Yoda (ruleset) to send emails to the Postfix instance
+* Optionally configure canonical map entries for rewriting email addresses
 
 ### Postfix
 
@@ -72,6 +75,18 @@ Configure the Yoda ruleset to send email messages to the local Postfix instance:
 smtp_server: smtp://localhost:25
 smtp_auth: false
 smtp_starttls: false
+```
+
+### Canonical map
+
+If the Yoda instance has accounts with names that do not relate to real email addresses,
+the `postfix_canonical_map` dictionary can be used to make Postfix rewrite addresses.
+For example:
+
+```
+postfix_canonical_map:
+  datamanager@yoda.test: a.admin@uu.nl
+  researcher@yoda.test: a.admin@uu.nl
 ```
 
 ### See also

--- a/roles/postfix/defaults/main.yml
+++ b/roles/postfix/defaults/main.yml
@@ -18,3 +18,4 @@ postfix_smtp_enable_tls: true
 postfix_enable_debugging: false
 postfix_myhostname: yoda
 postfix_myorigin: "$mydomain"
+postfix_canonical_map: {}

--- a/roles/postfix/handlers/main.yml
+++ b/roles/postfix/handlers/main.yml
@@ -11,3 +11,9 @@
 - name: Systemd daemon reload
   ansible.builtin.systemd:
     daemon_reload: true
+
+
+- name: Load Postfix Canonical Map
+  ansible.builtin.command:
+    cmd: postmap canonical
+    chdir: /etc/postfix

--- a/roles/postfix/tasks/main.yml
+++ b/roles/postfix/tasks/main.yml
@@ -29,6 +29,7 @@
       myhostname: "{{ postfix_myhostname }}"
       myorigin: "{{ postfix_myorigin }}"
       mydestination: ""
+      canonical_maps: "hash:/etc/postfix/canonical"
   when: not ansible_check_mode
   notify: Restart Postfix
 
@@ -70,6 +71,16 @@
       debug_peer_list: "{{ postfix_relayhost }}"
       debug_peer_level: "3"
   notify: Restart Postfix
+
+
+- name: Write input for Postfix canonical map
+  ansible.builtin.template:
+    src: canonical.j2
+    dest: "/etc/postfix/canonical"
+    owner: root
+    group: root
+    mode: '0600'
+  notify: Load Postfix Canonical Map
 
 
 - name: Create Postfix relayhost credentials file

--- a/roles/postfix/templates/canonical.j2
+++ b/roles/postfix/templates/canonical.j2
@@ -1,0 +1,287 @@
+# CANONICAL(5)                                                      CANONICAL(5)
+# 
+# NAME
+#        canonical - Postfix canonical table format
+# 
+# SYNOPSIS
+#        postmap /etc/postfix/canonical
+# 
+#        postmap -q "string" /etc/postfix/canonical
+# 
+#        postmap -q - /etc/postfix/canonical <inputfile
+# 
+# DESCRIPTION
+#        The  optional canonical(5) table specifies an address map-
+#        ping for local and non-local  addresses.  The  mapping  is
+#        used  by the cleanup(8) daemon, before mail is stored into
+#        the queue.  The address mapping is recursive.
+# 
+#        Normally, the canonical(5) table is specified  as  a  text
+#        file  that serves as input to the postmap(1) command.  The
+#        result, an indexed file in dbm or db format, is  used  for
+#        fast  searching  by  the  mail system. Execute the command
+#        "postmap /etc/postfix/canonical"  to  rebuild  an  indexed
+#        file after changing the corresponding text file.
+# 
+#        When  the  table  is provided via other means such as NIS,
+#        LDAP or SQL, the same lookups are  done  as  for  ordinary
+#        indexed files.
+# 
+#        Alternatively,  the  table  can  be provided as a regular-
+#        expression map where patterns are given as regular expres-
+#        sions,  or lookups can be directed to TCP-based server. In
+#        those cases, the lookups are done in a slightly  different
+#        way  as  described below under "REGULAR EXPRESSION TABLES"
+#        or "TCP-BASED TABLES".
+# 
+#        By default the canonical(5) mapping affects  both  message
+#        header  addresses  (i.e. addresses that appear inside mes-
+#        sages) and message envelope addresses  (for  example,  the
+#        addresses  that  are used in SMTP protocol commands). This
+#        is controlled with the canonical_classes parameter.
+# 
+#        NOTE: Postfix versions 2.2 and later rewrite message head-
+#        ers  from  remote  SMTP clients only if the client matches
+#        the  local_header_rewrite_clients  parameter,  or  if  the
+#        remote_header_rewrite_domain configuration parameter spec-
+#        ifies a non-empty value. To get the behavior before  Post-
+#        fix    2.2,    specify   "local_header_rewrite_clients   =
+#        static:all".
+# 
+#        Typically, one would use the canonical(5) table to replace
+#        login   names   by  Firstname.Lastname,  or  to  clean  up
+#        addresses produced by legacy mail systems.
+# 
+#        The canonical(5) mapping is not to be confused  with  vir-
+#        tual  alias  support or with local aliasing. To change the
+#        destination but not the headers,  use  the  virtual(5)  or
+#        aliases(5) map instead.
+# 
+# CASE FOLDING
+#        The  search  string is folded to lowercase before database
+#        lookup. As of Postfix 2.3, the search string is  not  case
+#        folded  with database types such as regexp: or pcre: whose
+#        lookup fields can match both upper and lower case.
+# 
+# TABLE FORMAT
+#        The input format for the postmap(1) command is as follows:
+# 
+#        pattern result
+#               When  pattern matches a mail address, replace it by
+#               the corresponding result.
+# 
+#        blank lines and comments
+#               Empty lines and whitespace-only lines are  ignored,
+#               as  are  lines whose first non-whitespace character
+#               is a `#'.
+# 
+#        multi-line text
+#               A logical line starts with non-whitespace  text.  A
+#               line  that starts with whitespace continues a logi-
+#               cal line.
+# 
+# TABLE SEARCH ORDER
+#        With lookups from indexed files such as DB or DBM, or from
+#        networked   tables   such   as  NIS,  LDAP  or  SQL,  each
+#        user@domain query produces a sequence of query patterns as
+#        described below.
+#
+#        Each  query pattern is sent to each specified lookup table
+#        before trying the next query pattern,  until  a  match  is
+#        found.
+#
+#        user@domain address
+#               Replace user@domain by address. This form  has  the
+#               highest precedence.
+# 
+#               This  is  useful  to clean up addresses produced by
+#               legacy mail systems.  It can also be used  to  pro-
+#               duce  Firstname.Lastname  style  addresses, but see
+#               below for a simpler solution.
+# 
+#        user address
+#               Replace user@site by address when site is equal  to
+#               $myorigin,  when  site is listed in $mydestination,
+#               or  when  it  is  listed  in  $inet_interfaces   or
+#               $proxy_interfaces.
+# 
+#               This  form  is  useful for replacing login names by
+#               Firstname.Lastname.
+# 
+#        @domain address
+#               Replace other addresses in domain by address.  This
+#               form has the lowest precedence.
+# 
+#               Note:  @domain  is  a  wild-card. When this form is
+#               applied to recipient addresses,  the  Postfix  SMTP
+#               server  accepts  mail  for any recipient in domain,
+#               regardless of whether that recipient exists.   This
+#               may  turn  your  mail  system  into  a  backscatter
+#               source: Postfix first accepts mail for non-existent
+#               recipients  and  then  tries to return that mail as
+#               "undeliverable" to the often forged sender address.
+# 
+# RESULT ADDRESS REWRITING
+#        The lookup result is subject to address rewriting:
+# 
+#        o      When  the  result  has  the  form @otherdomain, the
+#               result becomes the same user in otherdomain.
+# 
+#        o      When "append_at_myorigin=yes", append  "@$myorigin"
+#               to addresses without "@domain".
+# 
+#        o      When "append_dot_mydomain=yes", append ".$mydomain"
+#               to addresses without ".domain".
+# 
+# ADDRESS EXTENSION
+#        When a mail address localpart contains the optional recip-
+#        ient  delimiter  (e.g., user+foo@domain), the lookup order
+#        becomes: user+foo@domain, user@domain, user+foo, user, and
+#        @domain.
+# 
+#        The   propagate_unmatched_extensions   parameter  controls
+#        whether an unmatched address extension  (+foo)  is  propa-
+#        gated to the result of table lookup.
+# 
+# REGULAR EXPRESSION TABLES
+#        This  section  describes how the table lookups change when
+#        the table is given in the form of regular expressions. For
+#        a  description  of regular expression lookup table syntax,
+#        see regexp_table(5) or pcre_table(5).
+# 
+#        Each pattern is a regular expression that  is  applied  to
+#        the entire address being looked up. Thus, user@domain mail
+#        addresses are not broken up into their  user  and  @domain
+#        constituent parts, nor is user+foo broken up into user and
+#        foo.
+# 
+#        Patterns are applied in the order as specified in the  ta-
+#        ble,  until  a  pattern  is  found that matches the search
+#        string.
+# 
+#        Results are the same as with indexed  file  lookups,  with
+#        the  additional feature that parenthesized substrings from
+#        the pattern can be interpolated as $1, $2 and so on.
+# 
+# TCP-BASED TABLES
+#        This section describes how the table lookups  change  when
+#        lookups are directed to a TCP-based server. For a descrip-
+#        tion of the TCP client/server lookup protocol, see tcp_ta-
+#        ble(5).  This feature is not available up to and including
+#        Postfix version 2.4.
+# 
+#        Each lookup operation uses the entire address once.  Thus,
+#        user@domain  mail  addresses  are not broken up into their
+#        user and @domain constituent parts, nor is user+foo broken
+#        up into user and foo.
+# 
+#        Results are the same as with indexed file lookups.
+# 
+# BUGS
+#        The  table format does not understand quoting conventions.
+# 
+# CONFIGURATION PARAMETERS
+#        The following main.cf parameters are especially  relevant.
+#        The  text  below  provides  only  a parameter summary. See
+#        postconf(5) for more details including examples.
+# 
+#        canonical_classes
+#               What addresses are  subject  to  canonical  address
+#               mapping.
+# 
+#        canonical_maps
+#               List of canonical mapping tables.
+# 
+#        recipient_canonical_maps
+#               Address  mapping  lookup  table  for  envelope  and
+#               header recipient addresses.
+# 
+#        sender_canonical_maps
+#               Address  mapping  lookup  table  for  envelope  and
+#               header sender addresses.
+# 
+#        propagate_unmatched_extensions
+#               A  list  of  address rewriting or forwarding mecha-
+#               nisms that propagate an address extension from  the
+#               original  address  to  the result.  Specify zero or
+#               more  of  canonical,   virtual,   alias,   forward,
+#               include, or generic.
+# 
+#        Other parameters of interest:
+# 
+#        inet_interfaces
+#               The  network  interface  addresses that this system
+#               receives mail on.  You need to stop and start Post-
+#               fix when this parameter changes.
+# 
+#        local_header_rewrite_clients
+#               Rewrite message header addresses in mail from these
+#               clients and update incomplete  addresses  with  the
+#               domain name in $myorigin or $mydomain; either don't
+#               rewrite message headers from other clients at  all,
+#               or  rewrite  message  headers and update incomplete
+#               addresses  with  the  domain   specified   in   the
+#               remote_header_rewrite_domain parameter.
+# 
+#        proxy_interfaces
+#               Other interfaces that this machine receives mail on
+#               by way of a proxy agent or network address transla-
+#               tor.
+# 
+#        masquerade_classes
+#               List  of  address  classes subject to masquerading:
+#               zero or more of  envelope_sender,  envelope_recipi-
+#               ent, header_sender, header_recipient.
+# 
+#        masquerade_domains
+#               List  of  domains  that hide their subdomain struc-
+#               ture.
+# 
+#        masquerade_exceptions
+#               List of user names that are not subject to  address
+#               masquerading.
+# 
+#        mydestination
+#               List  of  domains  that  this mail system considers
+#               local.
+# 
+#        myorigin
+#               The domain that is appended to locally-posted mail.
+# 
+#        owner_request_special
+#               Give special treatment to owner-xxx and xxx-request
+#               addresses.
+# 
+#        remote_header_rewrite_domain
+#               Don't rewrite message headers from  remote  clients
+#               at all when this parameter is empty; otherwise, re-
+#               write message  headers  and  append  the  specified
+#               domain name to incomplete addresses.
+# 
+# SEE ALSO
+#        cleanup(8), canonicalize and enqueue mail
+#        postmap(1), Postfix lookup table manager
+#        postconf(5), configuration parameters
+#        virtual(5), virtual aliasing
+# 
+# README FILES
+#        Use  "postconf  readme_directory" or "postconf html_direc-
+#        tory" to locate this information.
+#        DATABASE_README, Postfix lookup table overview
+#        ADDRESS_REWRITING_README, address rewriting guide
+# 
+# LICENSE
+#        The Secure Mailer license must be  distributed  with  this
+#        software.
+# 
+# AUTHOR(S)
+#        Wietse Venema
+#        IBM T.J. Watson Research
+#        P.O. Box 704
+#        Yorktown Heights, NY 10598, USA
+# 
+#                                                                   CANONICAL(5)
+
+{% for from, to in postfix_canonical_map.items() %}
+{{ from }} {{ to }}
+{% endfor %}


### PR DESCRIPTION
Intended for optionally rewriting internal domain email addresses of Yoda accounts to public email addresses.