### PR TITLE
YDA-5051: fix missing PRC dependency

### DIFF
--- a/roles/irods_resource/meta/main.yml
+++ b/roles/irods_resource/meta/main.yml
@@ -9,3 +9,6 @@ galaxy_info:
   platforms:
     - name: CentOS
       version: 7
+
+dependencies:
+  - python_irodsclient


### PR DESCRIPTION
Resource servers also need the python_irodsclient role, because the ruleset install depends on pip being upgraded; fixes #210.