### PR TITLE
Test playbook: run revision job

### DIFF
--- a/roles/yoda_test/tasks/main.yml
+++ b/roles/yoda_test/tasks/main.yml
@@ -15,3 +15,5 @@
   when: yoda_environment == "testing"
 - name: Install data
   ansible.builtin.import_tasks: install-data.yml
+- name: Run revision job
+  ansible.builtin.import_tasks: run-revision-job.yml

--- a/roles/yoda_test/tasks/run-revision-job.yml
+++ b/roles/yoda_test/tasks/run-revision-job.yml
@@ -1,0 +1,8 @@
+---
+# copyright Utrecht University
+
+- name: Run revision job in order to ensure data for revision tests is present
+  become_user: '{{ irods_service_account }}'
+  become: true
+  ansible.builtin.command:
+    /bin/python /etc/irods/yoda-ruleset/tools/async-data-revision.py


### PR DESCRIPTION
This prevents the API revision tests from failing if they are run after the test playbook has run, but before the regular revision cronjob has run.