### PR TITLE
Make ruleset install more robust

### DIFF
--- a/roles/yoda_rulesets/tasks/main.yml
+++ b/roles/yoda_rulesets/tasks/main.yml
@@ -115,7 +115,8 @@
   community.general.make:
     chdir: "/etc/irods/{{ item.0.name }}"
     target: install
-  when: item.1.changed or ( 'repo' in item.0 and 'patch' in item.0 )
+  when: "'repo' in item.0"
+  changed_when: item.1.changed or ( 'repo' in item.0 and 'patch' in item.0 )
   with_together:
     - "{{ extra_rulesets + core_rulesets }}"
     - "{{ repochanges.results }}"


### PR DESCRIPTION
Different versions of Ansible have different interpretations of when a git repository has status 'changed'. This results in the make install step not triggering on newly installed rulesets on some Ansible versions. This change works around such version differences by always triggering make install on repository-based rulesets.