### PR TITLE
YDA-5145: improve MOAI robustness

### DIFF
--- a/roles/yoda_moai/tasks/main.yml
+++ b/roles/yoda_moai/tasks/main.yml
@@ -174,6 +174,20 @@
   when: ansible_selinux.status == "enabled"
 
 
+- name: Set SELinux context for MOAI log file
+  community.general.sefcontext:
+    target: '{{ yoda_moai_home }}//moai.log'
+    setype: httpd_sys_rw_content_t
+    state: present
+  register: moailog_context
+  when: ansible_selinux.status == "enabled"
+
+
+- name: Ensure selinux context is enforced on Yoda MOAI log
+  ansible.builtin.command: 'restorecon {{ yoda_moai_home }}/moai.log'
+  when: ansible_selinux.status == "enabled" and moailog_context.changed
+
+
 - name: Ensure selinux context is enforced on shared libraries
   ansible.builtin.command: 'restorecon -r {{ yoda_moai_home }}/yoda-moai/venv'
   when: ansible_selinux.status == "enabled" and filescontext.changed


### PR DESCRIPTION
This permits the MOAI web application to write messages to its log file, so that we can log any errors during processing metadata for later review by admins.