### PR TITLE
YDA-5139: run rev/repl jobs in verbose mode

### DIFF
--- a/docs/administration/configuring-yoda.md
+++ b/docs/administration/configuring-yoda.md
@@ -190,21 +190,23 @@ s3_auth_file                         | S3 authentication file name (default valu
 
 ### Research module configuration
 
-Variable   | Description
------------|---------------------------------------------
-default_yoda_schema          | Default Yoda XML scheme: default-0 or default-1
-enable_revisions             | Enable revisions: yes (1) or no (0)
-enable_revision_cleanup      | Enable cleanup job for removing old revisions (true/false, default: true)
-enable_async_replication     | Enable asynchronous replication cronjob: yes (1) or no (0)
-revision_strategy            | Revision strategy: A, B, J or Simple
-yoda_random_id_length        | Length of random ID to add to persistent identifier
-yoda_prefix                  | Prefix for internal portion of persistent identifier
-update_rulesets              | Update already installed rulesets with git
+Variable                       | Description
+-------------------------------|---------------------------------------------
+default_yoda_schema            | Default Yoda XML scheme: default-0 or default-1
+enable_revisions               | Enable revisions: yes (1) or no (0)
+async_revision_verbose_mode    | Enable verbose logging revision job (true/false, default: true)
+enable_revision_cleanup        | Enable cleanup job for removing old revisions (true/false, default: true)
+enable_async_replication       | Enable asynchronous replication cronjob: yes (1) or no (0)
+async_replication_verbose_mode | Enable verbose logging replication job (true/false, default: true)
+revision_strategy              | Revision strategy: A, B, J or Simple
+yoda_random_id_length          | Length of random ID to add to persistent identifier
+yoda_prefix                    | Prefix for internal portion of persistent identifier
+update_rulesets                | Update already installed rulesets with git
 override_resc_install_rulesets | Install rulesets on server even if it is a resource server (default: false). This override parameter can be used on resource servers that have an additional role, e.g. DavRODS server
-update_schemas               | Update already installed schemas, formelements and stylesheets: yes (1) or no (0)
-credential_files             | Location of Yoda credentials files
-temporary_files              | List of temporary files for cleanup functionality
-metadata_schemas             | List of metadata schemas to install on the system
+update_schemas                 | Update already installed schemas, formelements and stylesheets: yes (1) or no (0)
+credential_files               | Location of Yoda credentials files
+temporary_files                | List of temporary files for cleanup functionality
+metadata_schemas               | List of metadata schemas to install on the system
 
 ### Deposit module configuration
 

--- a/docs/administration/troubleshooting-replication-revisions.md
+++ b/docs/administration/troubleshooting-replication-revisions.md
@@ -13,7 +13,19 @@ Generic information about these background jobs can be found on
 [the page about background processes](../design/processes/asynchronous-processes.md). This page
 contains advice regarding how to troubleshoot these processes.
 
-If a data object is not replicated or does not get a new revision, consider first stopping and
+In Yoda 1.9 and higher, the revision and replication jobs run in verbose mode by default, which means
+the rodsLog typically has information regarding which data objects are being processed by these
+jobs. A good first step is to look up in the rodsLog what the relevant job is doing and
+whether the jobs show any errors, in particular permission errors (which are a common cause of
+replication/revision errors). When in doubt about whether permissions are correct, you can use
+the `iget` command to verify that a data object is accessible to the rods account.
+
+If a job is not configured to run in verbose mode, you can run it in verbose mode manually
+(see below).
+
+## Running a job in verbose mode manually
+
+If a data object is not replicated or does not get a new revision, consider stopping and
 temporarily disabling the background process cronjob for troubleshooting. This can be done
 by temporarily setting the background process stop flag (`/ZONE/yoda/flags/stop_replication` or
 `/ZONE/yoda/flags/stop_revisions`) and waiting for the job to finish.
@@ -35,7 +47,3 @@ command for the replication job:
 ```
 /bin/python /etc/irods/yoda-ruleset/tools/async-data-replicate.py -v
 ```
-
-Failures during revision creation are often caused by permission problems. First run the cron job in
-verbose mode to determine which data object is causing the problem. Then verify that the data object
-is accessible to the rods account, e.g. using an `iget` command.

--- a/roles/yoda_rulesets/defaults/main.yml
+++ b/roles/yoda_rulesets/defaults/main.yml
@@ -21,10 +21,12 @@ extra_rulesets: []
 
 # UU Module specific configuration
 enable_async_replication: 1
+async_replication_verbose_mode: true
 
 # Research module specific configuration.
 default_yoda_schema: default-0   # Default Yoda metadata scheme: default-0 or default-1
 enable_revisions: 1              # Enable revisions: yes (1) or no (0)
+async_revision_verbose_mode: true
 enable_revision_cleanup: true    # Enable revision cleanup job (true/false)
 revision_strategy: B             # Revision strategy: A, B, J or Simple
 yoda_instance: "{{ instance }}"

--- a/roles/yoda_rulesets/tasks/yoda-ruleset.yml
+++ b/roles/yoda_rulesets/tasks/yoda-ruleset.yml
@@ -458,7 +458,7 @@
   ansible.builtin.cron:
     name: 'asynchronous-replication'
     minute: '*/5'
-    job: '/bin/python /etc/irods/yoda-ruleset/tools/async-data-replicate.py >/dev/null 2>&1'
+    job: '/bin/python /etc/irods/yoda-ruleset/tools/async-data-replicate.py {{ "-v" if async_replication_verbose_mode else "" }} >/dev/null 2>&1'
     state: '{{ "present" if enable_async_replication == 1 else "absent" }}'
 
 
@@ -468,7 +468,7 @@
   ansible.builtin.cron:
     name: 'asynchronous-revisions'
     minute: '6,16,26,36,46,56'
-    job: '/bin/python /etc/irods/yoda-ruleset/tools/async-data-revision.py >/dev/null 2>&1'
+    job: '/bin/python /etc/irods/yoda-ruleset/tools/async-data-revision.py {{ "-v" if async_revision_verbose_mode else "" }} >/dev/null 2>&1'
     state: '{{ "present" if enable_revisions == 1 else "absent" }}'
 
 


### PR DESCRIPTION
Run asynchronous replication and revision jobs in verbose mode by default, as per ops team request, so that more information is available for troubleshooting.