### PR TITLE
YDA-5195: extract ODBC role from postgresql

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -115,6 +115,7 @@
   become: true
   roles:
     - pam_python
+    - postgresql_odbc
     - irods_icat
     - irods_runtime
     - role: irods_resource_plugin_s3

--- a/roles/postgresql/tasks/main.yml
+++ b/roles/postgresql/tasks/main.yml
@@ -108,28 +108,6 @@
   when: "'postgresql-server' in ansible_facts.packages and postgresql_perform_db_upgrade"
 
 
-- name: Check that ODBC is configured for PostgreSQL
-  ansible.builtin.lineinfile:
-    path: "{{ odbc_config_path }}"
-    search_string: "pgsql-{{ pgsql_version }}"
-    state: absent
-  check_mode: true
-  changed_when: false
-  register: driver
-
-
-- name: Configure ODBC for PostgreSQL
-  ansible.builtin.command: # noqa no-changed-when
-    cmd: odbcinst -i -d -r
-  args:
-    stdin: |
-      [PostgreSQL]
-      Description = PostgreSQL {{ pgsql_version }} ODBC Driver
-      Driver      = /usr/pgsql-{{ pgsql_version }}/lib/psqlodbc.so
-      Setup       = /usr/pgsql-{{ pgsql_version }}/lib/psqlodbcw.so
-  when: not driver.found
-
-
 - name: Ensure PostgreSQL is enabled and started
   ansible.builtin.service:
     name: "{{ postgresql_daemon }}"

--- a/roles/postgresql/tasks/setup-debian.yml
+++ b/roles/postgresql/tasks/setup-debian.yml
@@ -8,6 +8,5 @@
       - "postgresql-{{ pgsql_version }}"
       - "postgresql-contrib-{{ pgsql_version }}"
       - python3-psycopg2
-      - unixodbc
       - acl
     state: present

--- a/roles/postgresql/tasks/setup-redhat.yml
+++ b/roles/postgresql/tasks/setup-redhat.yml
@@ -14,8 +14,6 @@
     name:
       - "postgresql{{ pgsql_version }}-server"
       - "postgresql{{ pgsql_version }}-contrib"
-      - "postgresql{{ pgsql_version }}-odbc"
-      - unixODBC
     state: present
   when: not ansible_check_mode
 

--- a/roles/postgresql/vars/Debian.yml
+++ b/roles/postgresql/vars/Debian.yml
@@ -9,6 +9,4 @@ postgresql_bin_path: "/usr/lib/postgresql/{{ __postgresql_version }}/bin"
 postgresql_config_path: "/etc/postgresql/{{ pgsql_version }}/main"
 postgresql_daemon: 'postgresql'
 
-odbc_config_path: '/etc/odbc.ini'
-
 postgresqltuner_dir: "/var/lib/postgresql"

--- a/roles/postgresql/vars/RedHat.yml
+++ b/roles/postgresql/vars/RedHat.yml
@@ -9,6 +9,4 @@ postgresql_bin_path: "/usr/pgsql-{{ pgsql_version }}/bin/"
 postgresql_config_path: "/var/lib/pgsql/{{ pgsql_version }}/data"
 postgresql_daemon: 'postgresql-{{ pgsql_version }}'
 
-odbc_config_path: '/etc/odbcinst.ini'
-
 postgresqltuner_dir: "/var/lib/pgsql"

--- a/roles/postgresql_odbc/defaults/main.yml
+++ b/roles/postgresql_odbc/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# copyright Utrecht University
+
+pgsql_version: 11

--- a/roles/postgresql_odbc/meta/main.yml
+++ b/roles/postgresql_odbc/meta/main.yml
@@ -1,0 +1,18 @@
+---
+# copyright Utrecht University
+
+galaxy_info:
+  author: Lazlo Westerhof and Sietse Snel
+  description: Install and configure PostgreSQL ODBC
+  license: GPLv3
+  min_ansible_version: '2.11'
+  platforms:
+    - name: EL
+      version:
+        - 7
+        - 8
+    - name: Ubuntu
+      version: focal
+
+dependencies:
+  - role: postgresql_repository

--- a/roles/postgresql_odbc/tasks/main.yml
+++ b/roles/postgresql_odbc/tasks/main.yml
@@ -1,0 +1,42 @@
+---
+# copyright Utrecht University
+
+- name: Collect package facts
+  ansible.builtin.package_facts:
+    manager: auto
+
+
+- name: Include OS-specific variables
+  ansible.builtin.include_vars: "{{ ansible_os_family }}.yml"
+
+
+- name: Setup ODBC for RedHat family
+  ansible.builtin.include_tasks: setup-redhat.yml
+  when: ansible_os_family == 'RedHat'
+
+
+- name: Setup ODBC for Debian family
+  ansible.builtin.include_tasks: setup-debian.yml
+  when: ansible_os_family == 'Debian'
+
+
+- name: Check that ODBC is configured for PostgreSQL
+  ansible.builtin.lineinfile:
+    path: "{{ odbc_config_path }}"
+    search_string: "pgsql-{{ pgsql_version }}"
+    state: absent
+  check_mode: true
+  changed_when: false
+  register: driver
+
+
+- name: Configure ODBC for PostgreSQL
+  ansible.builtin.command: # noqa no-changed-when
+    cmd: odbcinst -i -d -r
+  args:
+    stdin: |
+      [PostgreSQL]
+      Description = PostgreSQL {{ pgsql_version }} ODBC Driver
+      Driver      = /usr/pgsql-{{ pgsql_version }}/lib/psqlodbc.so
+      Setup       = /usr/pgsql-{{ pgsql_version }}/lib/psqlodbcw.so
+  when: not driver.found

--- a/roles/postgresql_odbc/tasks/setup-debian.yml
+++ b/roles/postgresql_odbc/tasks/setup-debian.yml
@@ -1,0 +1,9 @@
+---
+# copyright Utrecht University
+
+
+- name: Ensure ODBC has been installed
+  ansible.builtin.package:
+    name:
+      - unixodbc
+    state: present

--- a/roles/postgresql_odbc/tasks/setup-redhat.yml
+++ b/roles/postgresql_odbc/tasks/setup-redhat.yml
@@ -1,0 +1,18 @@
+---
+# copyright Utrecht University
+
+# Not supported by DNF module, so just run the command instead.
+- name: "Disable RHEL PostgreSQL module (EL8)"
+  ansible.builtin.command:  # noqa no-changed-when
+    cmd: "dnf -qy module disable postgresql"
+  changed_when: false
+  when: ansible_distribution_major_version == "8"
+
+
+- name: Ensure PostgreSQL ODBC dependencies are installed
+  ansible.builtin.package:
+    name:
+      - "postgresql{{ pgsql_version }}-odbc"
+      - unixODBC
+    state: present
+  when: not ansible_check_mode

--- a/roles/postgresql_odbc/vars/Debian.yml
+++ b/roles/postgresql_odbc/vars/Debian.yml
@@ -1,0 +1,4 @@
+---
+# copyright Utrecht University
+
+odbc_config_path: '/etc/odbc.ini'

--- a/roles/postgresql_odbc/vars/RedHat.yml
+++ b/roles/postgresql_odbc/vars/RedHat.yml
@@ -1,0 +1,4 @@
+---
+# copyright Utrecht University
+
+odbc_config_path: '/etc/odbcinst.ini'


### PR DESCRIPTION
Extract separate ODBC role from PostgreSQL role so that right ODBC versions gets installed on provider when using a separate database server.

Draft, pending tests with various development configurations.