### PR TITLE
Development stats rename monthly storage

### DIFF
--- a/docker/run-cronjob.sh
+++ b/docker/run-cronjob.sh
@@ -37,7 +37,7 @@ case "$1" in
     ;;
 
   statistics)
-    docker exec -it provider.yoda sudo -iu irods /bin/irule -r irods_rule_engine_plugin-irods_rule_language-instance -F /etc/irods/yoda-ruleset/tools/monthly-storage-statistics.r
+    docker exec -it provider.yoda sudo -iu irods /bin/irule -r irods_rule_engine_plugin-irods_rule_language-instance -F /etc/irods/yoda-ruleset/tools/storage-statistics.r
     ;;
 
   weeklyreport)

--- a/roles/yoda_rulesets/defaults/main.yml
+++ b/roles/yoda_rulesets/defaults/main.yml
@@ -10,7 +10,7 @@ core_rulesets:
   - name: yoda-ruleset
     repo: https://github.com/UtrechtUniversity/yoda-ruleset.git
     ruleset_name: rules-uu
-    version: "development-stats-rename-monthly-storage"
+    version: "{{ yoda_version }}"
     install_scripts: true
   - name: core
     ruleset_name: core

--- a/roles/yoda_rulesets/defaults/main.yml
+++ b/roles/yoda_rulesets/defaults/main.yml
@@ -10,7 +10,7 @@ core_rulesets:
   - name: yoda-ruleset
     repo: https://github.com/UtrechtUniversity/yoda-ruleset.git
     ruleset_name: rules-uu
-    version: "{{ yoda_version }}"
+    version: "development-stats-rename-monthly-storage"
     install_scripts: true
   - name: core
     ruleset_name: core

--- a/roles/yoda_rulesets/tasks/yoda-ruleset.yml
+++ b/roles/yoda_rulesets/tasks/yoda-ruleset.yml
@@ -58,6 +58,14 @@
   register: storage_statistics
 
 
+- name: Remove legacy monthly storage statistics gathering cronjob
+  become_user: "{{ irods_service_account }}"
+  become: true
+  ansible.builtin.cron:
+    name: 'monthly-storage-statistics'
+    state: absent
+
+
 - name: Enable storage statistics gathering cronjob
   become_user: "{{ irods_service_account }}"
   become: true
@@ -65,7 +73,7 @@
     name: 'storage-statistics'
     minute: '0'
     hour: '5'
-    day: '1'
+    day: '*'
     job: >
       /bin/irule -r irods_rule_engine_plugin-irods_rule_language-instance -F
       /etc/irods/yoda-ruleset/tools/storage-statistics.r >>/var/lib/irods/log/job_storage-statistics.log 2>&1

--- a/roles/yoda_rulesets/tasks/yoda-ruleset.yml
+++ b/roles/yoda_rulesets/tasks/yoda-ruleset.yml
@@ -54,7 +54,7 @@
   become_user: "{{ irods_service_account }}"
   become: true
   ansible.builtin.stat:
-    path: /etc/irods/yoda-ruleset/tools/monthly-storage-statistics.r
+    path: /etc/irods/yoda-ruleset/tools/storage-statistics.r
   register: storage_statistics
 
 

--- a/roles/yoda_rulesets/tasks/yoda-ruleset.yml
+++ b/roles/yoda_rulesets/tasks/yoda-ruleset.yml
@@ -55,21 +55,21 @@
   become: true
   ansible.builtin.stat:
     path: /etc/irods/yoda-ruleset/tools/monthly-storage-statistics.r
-  register: monthly_storage_statistics
+  register: storage_statistics
 
 
 - name: Enable storage statistics gathering cronjob
   become_user: "{{ irods_service_account }}"
   become: true
   ansible.builtin.cron:
-    name: 'monthly-storage-statistics'
+    name: 'storage-statistics'
     minute: '0'
     hour: '5'
     day: '1'
     job: >
       /bin/irule -r irods_rule_engine_plugin-irods_rule_language-instance -F
-      /etc/irods/yoda-ruleset/tools/monthly-storage-statistics.r >>/var/lib/irods/log/job_monthly-storage-statistics.log 2>&1
-  when: monthly_storage_statistics.stat.exists
+      /etc/irods/yoda-ruleset/tools/storage-statistics.r >>/var/lib/irods/log/job_storage-statistics.log 2>&1
+  when: storage_statistics.stat.exists
 
 
 - name: Create local Yoda ruleset configuration

--- a/roles/yoda_test/tasks/install-data.yml
+++ b/roles/yoda_test/tasks/install-data.yml
@@ -224,11 +224,11 @@
     job: '/bin/irule -r irods_rule_engine_plugin-irods_rule_language-instance -F /var/lib/irods/.irods/job_checksums.r >> /var/lib/irods/log/job_checksums.log 2>&1'
 
 
-- name: Run monthly storage statistics job
+- name: Run storage statistics job
   become_user: '{{ irods_service_account }}'
   become: true
   ansible.builtin.command:
-    irule -r irods_rule_engine_plugin-irods_rule_language-instance -F /etc/irods/yoda-ruleset/tools/monthly-storage-statistics.r
+    irule -r irods_rule_engine_plugin-irods_rule_language-instance -F /etc/irods/yoda-ruleset/tools/storage-statistics.r
   ignore_errors: true
 
 


### PR DESCRIPTION
as discussed:

-    version: "{{ yoda_version }}"
+    version: "development-stats-rename-monthly-storage"

has to be renamed back again into yoda_version 👍