### PR TITLE
CI: pin ansible-lint version

### DIFF
--- a/.github/workflows/ansible-lint-zabbix.yml
+++ b/.github/workflows/ansible-lint-zabbix.yml
@@ -20,6 +20,6 @@ jobs:
 
       - name: Run ansible-lint on Zabbix playbook
         # replace `main` with any valid ref, or tags like `v6`
-        uses: ansible-community/ansible-lint-action@main
+        uses: ansible-community/ansible-lint-action@v6.15.0
         with:
           path: "zabbix.yml"

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -28,6 +28,6 @@ jobs:
 
       - name: Run ansible-lint
         # replace `main` with any valid ref, or tags like `v6`
-        uses: ansible-community/ansible-lint-action@main
+        uses: ansible-community/ansible-lint-action@v6.15.0
         with:
           path: "playbook.yml"


### PR DESCRIPTION
So that we can choose when stricter rules in newer versions are applied, rather than stricter rules being introduced unexpectedly.