### PR TITLE
YDA-5237: pin urllib3 version dms-archive-mock

### DIFF
--- a/roles/dms_archive_mock/files/dms-archive-mock/setup.py
+++ b/roles/dms_archive_mock/files/dms-archive-mock/setup.py
@@ -16,6 +16,7 @@ setup(
                       'requests==2.31.0',
                       'numpy==1.19.5',
                       'typing-extensions==4.1.1',
+                      'urllib3>=1.21.1,<2',
                       'Werkzeug==2.2.3'],
     entry_points='''
     [console_scripts]


### PR DESCRIPTION
urllib3 v2.0 needs OpenSSL 1.1.1+, which is not yet available on CentOS 7