### PR TITLE
YDA-5284: add options for GoCommands CLI

### DIFF
--- a/docs/administration/configuring-yoda.md
+++ b/docs/administration/configuring-yoda.md
@@ -177,6 +177,9 @@ irods_enable_service                 | Whether to enable the iRODS service. Set 
 irods_rum_job_enabled                | Whether to enable the daily RUM job for removing unused metadata entries (default: true)
 irods_rum_job_hour                   | Time to run RUM job - hour (default: 20)
 irods_rum_job_minute                 | Time to run RUM job - minute (default: 0)
+irods_enable_gocommands              | Whether to install the GoCommands CLI (disabled by default)
+irods_gocommands_version             | GoCommands version
+irods_gocommands_archive_checksum    | MD5 checksum of the GoCommands archive for the version to be installed
 
 ### S3 configuration - for iRODS S3 resource plugin and s3cmd utilities
 

--- a/environments/development/allinone/group_vars/allinone.yml
+++ b/environments/development/allinone/group_vars/allinone.yml
@@ -85,6 +85,7 @@ irods_icat_fqdn: combined.yoda.test        # iRODS iCAT fully qualified domain n
 irods_database_fqdn: combined.yoda.test    # iRODS database fully qualified domain name (FQDN)
 irods_resource_fqdn: combined.yoda.test    # iRODS resource fully qualified domain name (FQDN)
 irods_ssl_verify_server: none              # Verify TLS certificate, use 'cert' for acceptance and production
+irods_enable_gocommands: false
 irods_resources:
   - name: dev001_1
     host: "{{ irods_icat_fqdn }}"

--- a/environments/development/el8-database/group_vars/el8.yml
+++ b/environments/development/el8-database/group_vars/el8.yml
@@ -79,6 +79,7 @@ irods_icat_fqdn: combined.yoda.test        # iRODS iCAT fully qualified domain n
 irods_database_fqdn: database.yoda.test    # iRODS database fully qualified domain name (FQDN)
 irods_resource_fqdn: combined.yoda.test    # iRODS resource fully qualified domain name (FQDN)
 irods_ssl_verify_server: none              # Verify TLS certificate, use 'cert' for acceptance and production
+irods_enable_gocommands: false
 irods_resources:
   - name: dev001_1
     host: "{{ irods_icat_fqdn }}"

--- a/environments/development/full/group_vars/full.yml
+++ b/environments/development/full/group_vars/full.yml
@@ -82,6 +82,7 @@ irods_icat_fqdn: icat.yoda.test            # iRODS iCAT fully qualified domain n
 irods_database_fqdn: database.yoda.test    # iRODS database fully qualified domain name (FQDN)
 irods_resource_fqdn: resource.yoda.test    # iRODS resource fully qualified domain name (FQDN)
 irods_ssl_verify_server: none              # Verify TLS certificate, use 'cert' for acceptance and production
+irods_enable_gocommands: false
 irods_resources:
   - name: dev001_1
     host: "{{ irods_icat_fqdn }}"

--- a/environments/development/surf/group_vars/surf.yml
+++ b/environments/development/surf/group_vars/surf.yml
@@ -82,6 +82,7 @@ irods_icat_fqdn: portal.surfyoda.test            # iRODS iCAT fully qualified do
 irods_database_fqdn: portal.surfyoda.test    # iRODS database fully qualified domain name (FQDN)
 #irods_resource_fqdn: resource.surfyoda.test    # iRODS resource fully qualified domain name (FQDN)
 irods_ssl_verify_server: none              # Verify TLS certificate, use 'cert' for acceptance and production
+irods_enable_gocommands: false
 irods_resources:
   - name: dev001_1
     host: "{{ yoda_davrods_fqdn }}"

--- a/environments/development/ubuntu/group_vars/ubuntu.yml
+++ b/environments/development/ubuntu/group_vars/ubuntu.yml
@@ -78,6 +78,7 @@ irods_icat_fqdn: combined.yoda.test        # iRODS iCAT fully qualified domain n
 irods_database_fqdn: database.yoda.test    # iRODS database fully qualified domain name (FQDN)
 irods_resource_fqdn: combined.yoda.test    # iRODS resource fully qualified domain name (FQDN)
 irods_ssl_verify_server: none              # Verify TLS certificate, use 'cert' for acceptance and production
+irods_enable_gocommands: false
 irods_resources:
   - name: dev001_1
     host: "{{ irods_icat_fqdn }}"

--- a/playbook.yml
+++ b/playbook.yml
@@ -141,6 +141,8 @@
       when: enable_postfix
     - role: mailpit
       when: enable_mailpit
+    - role: irods_gocommands
+      when: irods_enable_gocommands
   tags:
     - icat
 
@@ -155,6 +157,8 @@
     - irods_runtime
     - irods_microservices
     - irods_completion
+    - role: irods_gocommands
+      when: irods_enable_gocommands
     - role: irods_consistency_check
       when: enable_irods_consistency_check
   tags:

--- a/roles/irods_gocommands/defaults/main.yml
+++ b/roles/irods_gocommands/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# copyright Utrecht University
+
+irods_enable_gocommands: false
+irods_gocommands_version: 0.7.4
+irods_gocommands_archive_checksum: "md5:7ce94161cb3b4761018ed1eca8606a2d"

--- a/roles/irods_gocommands/meta/main.yml
+++ b/roles/irods_gocommands/meta/main.yml
@@ -1,0 +1,11 @@
+---
+# copyright Utrecht University
+
+galaxy_info:
+  author: Sietse Snel
+  description: Install iRODS GoCommands
+  license: GPLv3
+  min_ansible_version: "2.7"
+  platforms:
+    - name: EL
+      version: 7

--- a/roles/irods_gocommands/tasks/main.yml
+++ b/roles/irods_gocommands/tasks/main.yml
@@ -1,0 +1,48 @@
+---
+# copyright Utrecht University
+
+- name: Get iRODS home directory
+  become_user: '{{ irods_service_account }}'
+  become: true
+  ansible.builtin.command: echo ~
+  register: irods_directory
+  changed_when: false
+  check_mode: false
+
+
+- name: Create GoCommands directories
+  ansible.builtin.file:
+    path: '{{ item }}'
+    state: directory
+    mode: '0755'
+    owner: '{{ irods_service_account }}'
+    group: '{{ irods_service_account }}'
+  with_items:
+    - '{{ irods_directory.stdout }}/gocommands'
+    - '{{ irods_directory.stdout }}/gocommands/{{ irods_gocommands_version }}'
+
+
+- name: Download GoCommands
+  ansible.builtin.get_url:
+    url: 'https://github.com/cyverse/gocommands/releases/download/v{{ irods_gocommands_version }}/gocmd-v{{ irods_gocommands_version }}-linux-amd64.tar.gz'
+    dest: '{{ irods_directory.stdout }}/gocommands/gocmd-v{{ irods_gocommands_version }}-linux-amd64.tar.gz'
+    checksum: '{{ irods_gocommands_archive_checksum }}'
+    mode: '0644'
+
+
+- name: Extract GoCommands archive
+  ansible.builtin.unarchive:
+    src: '{{ irods_directory.stdout }}/gocommands/gocmd-v{{ irods_gocommands_version }}-linux-amd64.tar.gz'
+    dest: '{{ irods_directory.stdout }}/gocommands/{{ irods_gocommands_version }}'
+    remote_src: true
+    creates: '{{ irods_directory.stdout }}/gocommands/{{ irods_gocommands_version }}/gocmd'
+
+
+- name: Sync GoCommands executable to path
+  ansible.builtin.copy:
+    src: '{{ irods_directory.stdout }}/gocommands/{{ irods_gocommands_version }}/gocmd'
+    remote_src: true
+    dest: '/usr/bin/gocmd'
+    owner: irods
+    group: irods
+    mode: '755'


### PR DESCRIPTION
Installing GoCommands is disabled by default, for now.