### PR TITLE
YDA-5296: implement API call duration logging

### DIFF
--- a/docs/administration/configuring-yoda.md
+++ b/docs/administration/configuring-yoda.md
@@ -147,12 +147,19 @@ yoda_davrods_anonymous_fqdn  | Yoda Davrods anonymous WebDAV fully qualified dom
 yoda_davrods_logo_path       | Path of the DavRODS logo on the portal. Defaults to the themed logo.
 yoda_davrods_logo_link       | URL that the DavRODS logo is linked to (default:  https://www.uu.nl)
 yoda_enable_httpd            | Whether to enable the httpd service (boolean, default value: true). Set to false if manual actions are needed before starting the web server (e.g. mounting encrypted volumes)
-httpd_log_forwarded_for      | Whether to log X-Forwarded-For headers in Apache logs (boolean, default value: false). This logs source IP addresses of requests if requests to the Yoda web portal and/or WebDAV interface are routed via a load balancer.
-httpd_log_user_agent         | Whether to log the user agent of browsers and WebDAV clients in the Apache logs (boolean, default value: false)
 tcp_keepalive_time           | IPv4 TCP keepalives: time until first keepalive (kernel parameter). Can be useful to tune in order to prevent timeouts on long transfers.
 tcp_keepalive_intvl          | IPv4 TCP keepalives: time between keepalives (kernel parameter). Can be useful to tune in order to prevent timeouts on long transfers.
 yoda_theme                   | The theme to use for the Yoda Portal. See also [the theme documentation](../design/overview/theme-packages.md). By default, Yoda uses the UU theme.
 yoda_theme_path              | Path where themes for the Yoda Portal are retrieved from. See [the theme documentation](../design/overview/theme-packages.md) for more information.
+
+### Generic logging configuration
+
+Variable                           | Description
+-----------------------------------|---------------------------------------------
+httpd_log_forwarded_for            | Whether to log X-Forwarded-For headers in Apache logs (boolean, default value: false). This logs source IP addresses of requests if requests to the Yoda web portal and/or WebDAV interface are routed via a load balancer.
+httpd_log_user_agent               | Whether to log the user agent of browsers and WebDAV clients in the Apache logs (boolean, default value: false)
+yoda_portal_log_api_call_duration  | Whether to log duration and parameters of all API calls from the Yoda portal. This is mainly useful for performance testing (boolean, default value: false)
+
 
 ### iRODS configuration
 

--- a/environments/development/allinone/group_vars/allinone.yml
+++ b/environments/development/allinone/group_vars/allinone.yml
@@ -76,6 +76,7 @@ enable_icat_database_checker: true
 yoda_theme_path: /var/www/yoda/themes              # Base path holding customised portal themes
 yoda_theme: uu                                     # Yoda theme: uu or vu (default: uu)
 portal_title_text: Yoda - Dev
+yoda_portal_log_api_call_duration: true
 
 # iRODS configuration
 irods_password: rods                       # iRODS admin password

--- a/environments/development/el8-database/group_vars/el8.yml
+++ b/environments/development/el8-database/group_vars/el8.yml
@@ -70,6 +70,7 @@ sram_tls_verify: false                                 # Enable TLS verification
 yoda_theme_path: /var/www/yoda/themes              # Base path holding customised portal themes
 yoda_theme: uu                                     # Yoda theme: uu or vu (default: uu)
 portal_title_text: Yoda - Dev
+yoda_portal_log_api_call_duration: true
 
 # iRODS configuration
 irods_password: rods                       # iRODS admin password

--- a/environments/development/full/group_vars/full.yml
+++ b/environments/development/full/group_vars/full.yml
@@ -73,6 +73,7 @@ enable_icat_database_checker: true
 yoda_theme_path: /var/www/yoda/themes              # Base path holding customised portal themes
 yoda_theme: uu                                     # Yoda theme: uu or vu (default: uu)
 portal_title_text: Yoda - Dev
+yoda_portal_log_api_call_duration: true
 
 # iRODS configuration
 irods_password: rods                       # iRODS admin password

--- a/environments/development/surf/group_vars/surf.yml
+++ b/environments/development/surf/group_vars/surf.yml
@@ -73,6 +73,7 @@ enable_icat_database_checker: true
 yoda_theme_path: /var/www/yoda/themes              # Base path holding customised portal themes
 yoda_theme: uu                                     # Yoda theme: uu or vu (default: uu)
 portal_title_text: Yoda - Surf Config Test
+yoda_portal_log_api_call_duration: true
 
 # iRODS configuration
 irods_password: rods                       # iRODS admin password

--- a/environments/development/ubuntu/group_vars/ubuntu.yml
+++ b/environments/development/ubuntu/group_vars/ubuntu.yml
@@ -69,6 +69,7 @@ token_lifetime: 72                                      # Lifetime of data acces
 yoda_theme_path: /var/www/yoda/themes              # Base path holding customised portal themes
 yoda_theme: uu                                     # Yoda theme: uu or vu (default: uu)
 portal_title_text: Yoda - Dev
+yoda_portal_log_api_call_duration: true
 
 # iRODS configuration
 irods_password: rods                       # iRODS admin password

--- a/roles/yoda_portal/defaults/main.yml
+++ b/roles/yoda_portal/defaults/main.yml
@@ -15,6 +15,7 @@ yoda_theme: uu                                     # Yoda theme: uu or vu (defau
 
 # Yoda portal
 yoda_portal_version: "{{ yoda_version }}"
+yoda_portal_log_api_call_duration: false
 
 # iRODS configuration.
 irods_default_resc: irodsResc              # iRODS default resource name

--- a/roles/yoda_portal/templates/flask.cfg.j2
+++ b/roles/yoda_portal/templates/flask.cfg.j2
@@ -16,6 +16,9 @@ TOKENS_ENABLED      = {{ enable_tokens }}
 TOKEN_LIFETIME      = {{ token_lifetime }}
 SRAM_ENABLED        = {{ enable_sram }}
 
+# Logging configuration
+LOG_API_CALL_DURATION       = {{ yoda_portal_log_api_call_duration }}
+
 # Flask-Session configuration
 SESSION_TYPE                = 'filesystem'
 SESSION_COOKIE_NAME         = '__Host-session'


### PR DESCRIPTION
Add parameter yoda_portal_log_api_call_duration, which can be used to log duration and parameters of all API calls from the portal. Intended for performance testing and troubleshooting.

Enabled by default on development environments, otherwise disabled by default.