### PR TITLE
YDA-5344: implement initial version ARB

### DIFF
--- a/docs/administration/configuring-yoda.md
+++ b/docs/administration/configuring-yoda.md
@@ -200,6 +200,19 @@ s3_secret_key                        | S3 secret key of S3 buckets (used by s3cm
 s3_hostname                          | S3 server hostname (used by s3cmd; the hostname used by the S3 resource plugin is configured in the S3 resource contexts instead)
 s3_auth_file                         | S3 authentication file name (default value: /var/lib/irods/.s3auth)
 
+### iRODS automatic resource balancing
+
+These parameters affect whether the Yoda ruleset configures iRODS to automatically stop creating
+new data objects on unixfilesystem resources that have less free storage space than a
+particular threshold.
+
+Variable                             | Description
+-------------------------------------|----------------------------------
+irods_arb_enabled                    | Enable automatic resource balancing (default: false). After switching from enabled to disabled, you would also need to manually clear the thresholds on the provider and consumer using `python /etc/irods/yoda-ruleset/tools/update-ufs-resources.py clear`.
+irods_arb_exempt_resources           | Comma-separated list of unixfilesystem resources that ARB should ignore (default: no resources are ignored)
+irods_arb_min_gb_free                | Minimum absolute amount of free space on unixfilesystem resources in GiB (default: 0)
+irods_arb_min_percent_free           | Minimum relative amount of free space on unixfilesystem resources in % (default: 5)
+
 ### Research module configuration
 
 Variable                       | Description

--- a/playbook.yml
+++ b/playbook.yml
@@ -125,6 +125,7 @@
     - irods_microservices
     - irods_completion
     - irods_rodsadmin
+    - irods_arb
     - role: irods_consistency_check
       when: enable_irods_consistency_check
     - role: icat_database_checker
@@ -157,6 +158,7 @@
     - irods_runtime
     - irods_microservices
     - irods_completion
+    - irods_arb
     - role: irods_gocommands
       when: irods_enable_gocommands
     - role: irods_consistency_check

--- a/roles/irods_arb/defaults/main.yml
+++ b/roles/irods_arb/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+# copyright Utrecht University
+
+irods_service_account: irods
+
+irods_arb_enabled: false
+irods_arb_exempt_resources: ""
+irods_arb_min_gb_free: 0
+irods_arb_min_percent_free: 5

--- a/roles/irods_arb/meta/main.yml
+++ b/roles/irods_arb/meta/main.yml
@@ -1,0 +1,15 @@
+---
+# copyright Utrecht University
+
+galaxy_info:
+  author: Sietse Snel
+  description: Install and configure automatic resource balancing in Yoda
+  license: GPLv3
+  min_ansible_version: '2.11'
+  platforms:
+    - name: EL
+      version: 7
+
+
+dependencies:
+  - role: python_irodsclient

--- a/roles/irods_arb/tasks/main.yml
+++ b/roles/irods_arb/tasks/main.yml
@@ -1,0 +1,17 @@
+# Copyright Utrecht University
+
+- name: Configure cronjob to update resource storage data
+  become_user: "{{ irods_service_account }}"
+  become: true
+  ansible.builtin.cron:
+    name: 'update-ufs-resources.py'
+    minute: '*'
+    hour: '*'
+    job: >
+      /usr/bin/python /etc/irods/yoda-ruleset/tools/update-ufs-resources.py
+      -e "{{ irods_arb_exempt_resources }}"
+      update
+      --min-percent-free "{{ irods_arb_min_percent_free }}"
+      --min-gb-free "{{ irods_arb_min_gb_free }}"
+      >& /dev/null
+    state: '{{ "present" if irods_arb_enabled else "absent" }}'


### PR DESCRIPTION
This is the first version of a configuration for making iRODS balance data across unixfilesystem resources in a tree, so that manually removing resources from a tree when they are almost full is usually no longer necessary.