### PR TITLE
YDA-5346: Zabbix timeout parameter change

### DIFF
--- a/roles/yoda_zabbix_system/defaults/main.yml
+++ b/roles/yoda_zabbix_system/defaults/main.yml
@@ -7,5 +7,6 @@ rpm_dest_dir: /tmp
 zabbix_version: "{{ yoda_version }}"
 
 zabbix_server: 192.168.56.20
+zabbix_timeout: 15               # in seconds (range: 1-30)
 
 repo_only: false # Only download packages from repos.

--- a/roles/yoda_zabbix_system/templates/zabbix_agentd.conf.j2
+++ b/roles/yoda_zabbix_system/templates/zabbix_agentd.conf.j2
@@ -236,6 +236,7 @@ HostnameItem=system.hostname
 # Range: 1-30
 # Default:
 # Timeout=3
+Timeout={{ zabbix_timeout }}
 
 ### Option: AllowRoot
 #	Allow the agent to run as 'root'. If disabled and the agent is started by 'root', the agent


### PR DESCRIPTION
Extract parameter for Zabbix timeout setting; set default value to 15 seconds, based on feedback from operations team.