### PR TITLE
Yda 5369 fix datarequest job scripts + other job fixes

### DIFF
--- a/roles/yoda_rulesets/tasks/yoda-ruleset.yml
+++ b/roles/yoda_rulesets/tasks/yoda-ruleset.yml
@@ -429,7 +429,7 @@
     name: 'job_movetovault.r'
     minute: '*/5'
     job: '{{ irods_directory.stdout }}/.irods/run-intake-movetovault.sh >& /dev/null'
-  when: enable_intake or yoda_environment in ["development", "testing"]
+    state: '{{ "present" if enable_intake else "absent" }}'
 
 
 - name: Set configuration AVUs for research ruleset to system collection

--- a/roles/yoda_rulesets/tasks/yoda-ruleset.yml
+++ b/roles/yoda_rulesets/tasks/yoda-ruleset.yml
@@ -672,6 +672,18 @@
     - admin-datarequest-temp-write-permission.sh
 
 
+- name: Remove data request module scripts from msiExecCmd if DR module not enabled
+  become_user: "{{ irods_service_account }}"
+  become: true
+  ansible.builtin.file:
+    path: "/var/lib/irods/msiExecCmd_bin/{{ item }}"
+    state: absent
+  when: not enable_datarequest
+  with_items:
+    - admin-datarequestactions.sh
+    - admin-datarequest-temp-write-permission.sh
+
+
 - name: Configure cronjob to check datarequest review period expiration
   become_user: "{{ irods_service_account }}"
   become: true
@@ -680,7 +692,7 @@
     hour: '*'
     job: '/bin/irule -r irods_rule_engine_plugin-irods_rule_language-instance -F
       /etc/irods/yoda-ruleset/tools/datarequest-check-review-period-expiration.r >/dev/null 2>&1'
-  when: enable_datarequest and not ansible_check_mode
+    state: '{{ "present" if enable_datarequest else "absent" }}'
 
 
 - name: Ensure token database is present

--- a/roles/yoda_rulesets/tasks/yoda-ruleset.yml
+++ b/roles/yoda_rulesets/tasks/yoda-ruleset.yml
@@ -600,6 +600,7 @@
     hour: '04'
     day: '1'
     job: '/bin/bash /etc/irods/yoda-ruleset/tools/notification/notification-data-access-token-expiry.sh >/dev/null 2>&1'
+    state: '{{ "present" if enable_tokens else "absent" }}'
 
 
 - name: Find out if datarequest system collection exists


### PR DESCRIPTION
This PR fixes YDA-5369.

It also contains two other cronjob-related fixes:
- Disable intake-to-vault cronjob when intake module has been disabled
- Disable DAP expiry notification cronjob when DAP authentication has been disabled