### PR TITLE
YDA-5462: add PRC dependency to ruleset role

### DIFF
--- a/roles/yoda_rulesets/meta/main.yml
+++ b/roles/yoda_rulesets/meta/main.yml
@@ -13,3 +13,4 @@ galaxy_info:
 
 dependencies:
   - role: python3
+  - role: python_irodsclient


### PR DESCRIPTION
During upgrades, we need to ensure that python-irodsclient is up-to-date before running the yoda_rulesets role, so that iRODS library functions used by the yoda_rulesets role (e.g. irods_setavu) can run with the right PRC version.