### PR TITLE
YDA-5548: limit image builds to main repo

### DIFF
--- a/.github/workflows/build-push-image-davrods.yml
+++ b/.github/workflows/build-push-image-davrods.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   push-image:
+    if: github.repository == 'utrechtuniversity/yoda'
     runs-on: ubuntu-22.04
     permissions:
       contents: read

--- a/.github/workflows/build-push-image-eus.yml
+++ b/.github/workflows/build-push-image-eus.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   push-image:
+    if: github.repository == 'utrechtuniversity/yoda'
     runs-on: ubuntu-22.04
     permissions:
       contents: read

--- a/.github/workflows/build-push-image-mailpit.yml
+++ b/.github/workflows/build-push-image-mailpit.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   push-image:
+    if: github.repository == 'utrechtuniversity/yoda'
     runs-on: ubuntu-22.04
     permissions:
       contents: read

--- a/.github/workflows/build-push-image-portal.yml
+++ b/.github/workflows/build-push-image-portal.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   push-image:
+    if: github.repository == 'utrechtuniversity/yoda'
     runs-on: ubuntu-22.04
     permissions:
       contents: read

--- a/.github/workflows/build-push-image-provider.yml
+++ b/.github/workflows/build-push-image-provider.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   push-image:
+    if: github.repository == 'utrechtuniversity/yoda'
     runs-on: ubuntu-22.04
     permissions:
       contents: read

--- a/.github/workflows/build-push-image-public.yml
+++ b/.github/workflows/build-push-image-public.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   push-image:
+    if: github.repository == 'utrechtuniversity/yoda'
     runs-on: ubuntu-22.04
     permissions:
       contents: read

--- a/.github/workflows/build-push-image-web-mock.yml
+++ b/.github/workflows/build-push-image-web-mock.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   push-image:
+    if: github.repository == 'utrechtuniversity/yoda'
     runs-on: ubuntu-22.04
     permissions:
       contents: read


### PR DESCRIPTION
Only build and push images when running on the main repo (not on forks)