### PR TITLE
Use only explicitly defined host groups for Yoda in version check

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -14,7 +14,7 @@
 
 
 - name: Check repository branches
-  hosts: all
+  hosts: databases,davrods,development,eus,icats,portals,publics,resources
   gather_facts: false
   pre_tasks:
     - name: Determine whether yoda version matches playbook version (branch or lightweight tag)
@@ -58,7 +58,7 @@
 
 
 - name: Provision common software and certificates
-  hosts: all
+  hosts: databases,davrods,development,eus,icats,portals,publics,resources
   become: true
   roles:
     - common


### PR DESCRIPTION
We may want to use (extra) inventories that include non-Yoda related hosts. They shouldn't have to be given an explicit "yoda_version".