### PR TITLE
PostgreSQL: add configuration option standard_conforming_strings

### DIFF
--- a/docker/compose-with-bind-mounts/docker-compose.yml
+++ b/docker/compose-with-bind-mounts/docker-compose.yml
@@ -36,6 +36,7 @@ services:
     platform: linux/amd64
     hostname: db.yoda
     image: postgres:15
+    command: postgres -c standard_conforming_strings=off
     environment:
       - POSTGRES_DB=ICAT
       - POSTGRES_USER=irodsdb

--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -30,6 +30,7 @@ services:
     platform: linux/amd64
     hostname: db.yoda
     image: postgres:15
+    command: postgres -c standard_conforming_strings=off 
     environment:
       - POSTGRES_DB=ICAT
       - POSTGRES_USER=irodsdb

--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     platform: linux/amd64
     hostname: db.yoda
     image: postgres:15
-    command: postgres -c standard_conforming_strings=off 
+    command: postgres -c standard_conforming_strings=off
     environment:
       - POSTGRES_DB=ICAT
       - POSTGRES_USER=irodsdb

--- a/roles/postgresql/defaults/main.yml
+++ b/roles/postgresql/defaults/main.yml
@@ -20,6 +20,7 @@ openssl_dhparams: dhparams.pem
 # General PostgreSQL configuration
 postgresql_timezone: 'Europe/Amsterdam'
 postgresql_max_connections: 100
+postgresql_standard_conforming_strings: 'off'     # https://docs.irods.org/4.2.12/system_overview/configuration/#special-characters
 
 # PostgreSQL performance-related configuration
 postgresql_shared_buffers: 32MB
@@ -32,6 +33,7 @@ postgresql_random_page_cost: "4.0"
 postgresql_log_line_prefix: '%m [%p] '
 postgresql_log_min_duration_statement: -1
 postgresql_log_autovacuum_min_duration: -1
+
 
 # PostgreSQL locale configuration
 icat_database_encoding: UTF-8

--- a/roles/postgresql/templates/postgresql-Debian.conf.j2
+++ b/roles/postgresql/templates/postgresql-Debian.conf.j2
@@ -783,7 +783,7 @@ default_text_search_config = 'pg_catalog.english'
 #escape_string_warning = on
 #lo_compat_privileges = off
 #quote_all_identifiers = off
-#standard_conforming_strings = on
+standard_conforming_strings = {{ postgresql_standard_conforming_strings }}
 #synchronize_seqscans = on
 
 # - Other Platforms and Clients -

--- a/roles/postgresql/templates/postgresql-RedHat.conf.j2
+++ b/roles/postgresql/templates/postgresql-RedHat.conf.j2
@@ -777,7 +777,7 @@ default_text_search_config = 'pg_catalog.english'
 #escape_string_warning = on
 #lo_compat_privileges = off
 #quote_all_identifiers = off
-#standard_conforming_strings = on
+standard_conforming_strings = {{ postgresql_standard_conforming_strings }}
 #synchronize_seqscans = on
 
 # - Other Platforms and Clients -


### PR DESCRIPTION
iRODS recommends standard_conforming_strings setting to 'off': https://docs.irods.org/4.2.12/system_overview/configuration/#special-characters