### PR TITLE
YDA-5615: ensure iRODS packages are pinned in Ubuntu setup

### DIFF
--- a/roles/irods_icat/tasks/main.yml
+++ b/roles/irods_icat/tasks/main.yml
@@ -79,6 +79,16 @@
   when: not ansible_check_mode
 
 
+- name: Ensure iRODS iCAT server and plugins are pinned
+  ansible.builtin.template:
+    src: 'irods_icat.pref.j2'
+    dest: '/etc/apt/preferences.d/irods_icat.pref'
+    mode: '0644'
+    owner: 'root'
+    group: 'root'
+  when: ansible_os_family == 'Debian'
+
+
 - name: Ensure iRODS indexing plugins are present
   ansible.builtin.package:
     name:
@@ -87,6 +97,16 @@
       - "{{ irods_dtp_package_new }}"
     state: present
   when: not ansible_check_mode and enable_open_search
+
+
+- name: Ensure iRODS indexing plugins are pinned
+  ansible.builtin.template:
+    src: 'irods_indexing.pref.j2'
+    dest: '/etc/apt/preferences.d/irods_indexing.pref'
+    mode: '0644'
+    owner: 'root'
+    group: 'root'
+  when: ansible_os_family == 'Debian' and enable_open_search
 
 
 - name: Flush handlers to restart iRODS if needed

--- a/roles/irods_icat/templates/irods_icat.pref.j2
+++ b/roles/irods_icat/templates/irods_icat.pref.j2
@@ -1,0 +1,25 @@
+# {{ ansible_managed }}
+
+{% set irods_server = irods_server_package_new.split('=') %}
+Explanation: Pin added by role: irods_icat
+Package: {{ irods_server[0] }}
+Pin: version {{ irods_server[1] }}
+Pin-Priority: 999
+
+{% set irods_runtime = irods_runtime_package_new.split('=') %}
+Explanation: Pin added by role: irods_icat
+Package: {{ irods_runtime[0] }}
+Pin: version {{ irods_runtime[1] }}
+Pin-Priority: 999
+
+{% set irods_pgp = irods_pgp_package_new.split('=') %}
+Explanation: Pin added by role: irods_icat
+Package: {{ irods_pgp[0] }}
+Pin: version {{ irods_pgp[1] }}
+Pin-Priority: 999
+
+{% set irods_prep = irods_prep_package_new.split('=') %}
+Explanation: Pin added by role: irods_icat
+Package: {{ irods_prep[0] }}
+Pin: version {{ irods_prep[1] }}
+Pin-Priority: 999

--- a/roles/irods_icat/templates/irods_indexing.pref.j2
+++ b/roles/irods_icat/templates/irods_indexing.pref.j2
@@ -1,0 +1,19 @@
+# {{ ansible_managed }}
+
+{% set irods_idp = irods_idp_package_new.split('=') %}
+Explanation: Pin added by role: irods_icat
+Package: {{ irods_idp[0] }}
+Pin: version {{ irods_idp[1] }}
+Pin-Priority: 999
+
+{% set irods_esp = irods_esp_package_new.split('=') %}
+Explanation: Pin added by role: irods_icat
+Package: {{ irods_esp[0] }}
+Pin: version {{ irods_esp[1] }}
+Pin-Priority: 999
+
+{% set irods_dtp = irods_dtp_package_new.split('=') %}
+Explanation: Pin added by role: irods_icat
+Package: {{ irods_dtp[0] }}
+Pin: version {{ irods_dtp[1] }}
+Pin-Priority: 999

--- a/roles/irods_icommands/tasks/main.yml
+++ b/roles/irods_icommands/tasks/main.yml
@@ -16,3 +16,13 @@
     name: '{{ irods_icommands_package_new }}'
     state: present
   when: not irods_server.stat.exists and not ansible_check_mode
+
+
+- name: Ensure iRODS iCommands is pinned
+  ansible.builtin.template:
+    src: 'irods_icommands.pref.j2'
+    dest: '/etc/apt/preferences.d/irods_icommands.pref'
+    mode: '0644'
+    owner: 'root'
+    group: 'root'
+  when: ansible_os_family == 'Debian'

--- a/roles/irods_icommands/templates/irods_icommands.pref.j2
+++ b/roles/irods_icommands/templates/irods_icommands.pref.j2
@@ -1,0 +1,7 @@
+# {{ ansible_managed }}
+
+{% set irods_icommands = irods_icommands_package_new.split('=') %}
+Explanation: Pin added by role: irods_icommands
+Package: {{ irods_icommands[0] }}
+Pin: version {{ irods_icommands[1] }}
+Pin-Priority: 999

--- a/roles/irods_resource/tasks/main.yml
+++ b/roles/irods_resource/tasks/main.yml
@@ -76,6 +76,16 @@
   when: not ansible_check_mode
 
 
+- name: Ensure iRODS resource server is pinned
+  ansible.builtin.template:
+    src: 'irods_resource.pref.j2'
+    dest: '/etc/apt/preferences.d/irods_resource.pref'
+    mode: '0644'
+    owner: 'root'
+    group: 'root'
+  when: ansible_os_family == 'Debian'
+
+
 - name: Flush handlers to restart iRODS if needed
   ansible.builtin.meta: flush_handlers
 

--- a/roles/irods_resource/templates/irods_resource.pref.j2
+++ b/roles/irods_resource/templates/irods_resource.pref.j2
@@ -1,0 +1,19 @@
+# {{ ansible_managed }}
+
+{% set irods_server = irods_server_package_new.split('=') %}
+Explanation: Pin added by role: irods_resource
+Package: {{ irods_server[0] }}
+Pin: version {{ irods_server[1] }}
+Pin-Priority: 999
+
+{% set irods_runtime = irods_runtime_package_new.split('=') %}
+Explanation: Pin added by role: irods_resource
+Package: {{ irods_runtime[0] }}
+Pin: version {{ irods_runtime[1] }}
+Pin-Priority: 999
+
+{% set irods_prep = irods_prep_package_new.split('=') %}
+Explanation: Pin added by role: irods_resource
+Package: {{ irods_prep[0] }}
+Pin: version {{ irods_prep[1] }}
+Pin-Priority: 999

--- a/roles/irods_resource_plugin_s3/tasks/main.yml
+++ b/roles/irods_resource_plugin_s3/tasks/main.yml
@@ -11,6 +11,16 @@
     state: present
 
 
+- name: Ensure iRODS resource plugin S3 is pinned
+  ansible.builtin.template:
+    src: 'irods_resource_plugin_s3.pref.j2'
+    dest: '/etc/apt/preferences.d/irods_resource_plugin_s3.pref'
+    mode: '0644'
+    owner: 'root'
+    group: 'root'
+  when: ansible_os_family == 'Debian'
+
+
 - name: Ensure S3 credentials file is present
   ansible.builtin.template:
     src: s3auth.j2

--- a/roles/irods_resource_plugin_s3/templates/irods_resource_plugin_s3.pref.j2
+++ b/roles/irods_resource_plugin_s3/templates/irods_resource_plugin_s3.pref.j2
@@ -1,0 +1,7 @@
+# {{ ansible_managed }}
+
+{% set irods_resource_plugin_s3 = irods_resource_plugin_s3_package.split('=') %}
+Explanation: Pin added by role: irods_resource_plugin_s3
+Package: {{ irods_resource_plugin_s3[0] }}
+Pin: version {{ irods_resource_plugin_s3[1] }}
+Pin-Priority: 999

--- a/roles/irods_runtime/tasks/main.yml
+++ b/roles/irods_runtime/tasks/main.yml
@@ -19,6 +19,16 @@
     state: present
 
 
+- name: Ensure iRODS runtime is pinned
+  ansible.builtin.template:
+    src: 'irods_runtime.pref.j2'
+    dest: '/etc/apt/preferences.d/irods_runtime.pref'
+    mode: '0644'
+    owner: 'root'
+    group: 'root'
+  when: ansible_os_family == 'Debian'
+
+
 - name: Determine current checksum of irods_server library
   ansible.builtin.command: "sha256sum /usr/lib/libirods_server.so.4.2.12"
   register: libirods_server_checksum

--- a/roles/irods_runtime/templates/irods_runtime.pref.j2
+++ b/roles/irods_runtime/templates/irods_runtime.pref.j2
@@ -1,0 +1,7 @@
+# {{ ansible_managed }}
+
+{% set irods_runtime = irods_runtime_package_new.split('=') %}
+Explanation: Pin added by role: irods_runtime
+Package: {{ irods_runtime[0] }}
+Pin: version {{ irods_runtime[1] }}
+Pin-Priority: 999


### PR DESCRIPTION
```
Pinned packages:
     irods-rule-engine-plugin-python -> 4.2.12.0-1~bionic with priority 999
     irods-server -> 4.2.12-1~bionic with priority 999
     irods-icommands -> 4.2.12-1~bionic with priority 999
     irods-runtime -> 4.2.12-1~bionic with priority 999
     irods-database-plugin-postgres -> 4.2.12-1~bionic with priority 999
```