### PR TITLE
Remove irods_service_type parameter

### DIFF
--- a/docs/administration/configuring-yoda.md
+++ b/docs/administration/configuring-yoda.md
@@ -187,9 +187,8 @@ irods_default_resc                   | iRODS default resource name
 irods_resc_trigger_pol               | List of text patterns for matching non-primary resources where changes also need to trigger policies (e.g. asynchronous replication). Example: ["^testResc$","^myResc$"]
 irods_ssl_verify_server              | Verify TLS certificate, use 'cert' for acceptance and production
 irods_resources                      | Definition of iRODS resources of this Yoda instance
-irods_service_type                   | Possible values: 'sysv' (System V) or 'systemd'
-irods_max_open_files                 | Maximum number of open files for iRODS service (only effective when irods_service_type is set to 'systemd')
-irods_enable_service                 | Whether to enable the iRODS service. Set to false if manual actions are needed before starting iRODS, e.g. mounting encrypted volumes (only effective when irods_service_type is set to 'systemd')
+irods_max_open_files                 | Maximum number of open files for iRODS service
+irods_enable_service                 | Whether to enable the iRODS service. Set to false if manual actions are needed before starting iRODS, e.g. mounting encrypted volumes
 irods_rum_job_enabled                | Whether to enable the daily RUM job for removing unused metadata entries (default: true)
 irods_rum_job_hour                   | Time to run RUM job - hour (default: 20)
 irods_rum_job_minute                 | Time to run RUM job - minute (default: 0)

--- a/roles/irods_icat/defaults/main.yml
+++ b/roles/irods_icat/defaults/main.yml
@@ -52,14 +52,9 @@ openssl_crt_signed_and_chain: localhost_and_chain.crt
 # OpenID Connect configuration
 oidc_userinfo_uri: ''
 
-# Service type. Possible values: 'sysv' and 'systemd' (Ubuntu only supports systemd)
-irods_service_type: 'systemd'
-
 # Whether to start iRODS at boot time.
 irods_enable_service: true
 
-# The max number of open files is only effective when
-# irods_service_type has been set to 'systemd'.
 irods_max_open_files: 131072
 
 # Data Access Tokens

--- a/roles/irods_icat/tasks/main.yml
+++ b/roles/irods_icat/tasks/main.yml
@@ -5,29 +5,8 @@
   ansible.builtin.include_vars: "{{ ansible_os_family }}.yml"
 
 
-- name: Check iRODS service type is supported
-  ansible.builtin.fail:
-    msg: 'Error: irods_service_type value not supported'
-  when: irods_service_type not in ["sysv", "systemd"]
-
-
 - name: Populate service facts
   ansible.builtin.service_facts:
-
-
-- name: Stop iRODS service before switching between init systems
-  ansible.builtin.service:
-    name: irods
-    state: stopped
-  when: ( ansible_os_family == 'RedHat' and
-        ((irods_service_type == "sysv" and
-          'irods.service' in services and
-          services['irods.service']['source'] == "systemd" and
-          services['irods.service']['state'] == "running")
-         or (irods_service_type == "systemd" and
-          'irods' in services and
-          services['irods']['source'] == "sysv" and
-          services['irods']['state'] == "running")))
 
 
 - name: Ensure systemd unit file present
@@ -38,34 +17,6 @@
     group: root
     mode: '0644'
   notify: Systemd daemon reload
-  when: irods_service_type == "systemd"
-
-
-- name: Ensure systemd unit file absent
-  ansible.builtin.file:
-    path: /lib/systemd/system/irods.service
-    state: absent
-  notify: Systemd daemon reload
-  when: irods_service_type == "sysv"
-
-
-- name: Flush handlers to trigger daemon reload after switching between init systems
-  ansible.builtin.meta: flush_handlers
-
-
-- name: Start iRODS service after switching between init systems
-  ansible.builtin.service:
-    name: irods
-    state: started
-  when: ( ansible_os_family == 'RedHat' and
-        ((irods_service_type == "sysv" and
-          'irods.service' in services and
-          services['irods.service']['source'] == "systemd" and
-          services['irods.service']['state'] == "running")
-         or (irods_service_type == "systemd" and
-          'irods' in services and
-          services['irods']['source'] == "sysv" and
-          services['irods']['state'] == "running")))
 
 
 - name: Ensure iRODS iCAT server and plugins are present
@@ -266,7 +217,6 @@
     name: irods
     enabled: "{{ irods_enable_service }}"
     use: service
-  when: irods_service_type == "systemd"
 
 
 - name: Wait until iRODS server is ready to receive requests

--- a/roles/irods_resource/defaults/main.yml
+++ b/roles/irods_resource/defaults/main.yml
@@ -22,12 +22,7 @@ openssl_dhparams: dhparams.pem
 openssl_key_signed: localhost.key
 openssl_crt_signed_and_chain: localhost_and_chain.crt
 
-# Service type. Possible values: 'sysv' and 'systemd'
-irods_service_type: 'systemd'
-
 # Whether to start iRODS at boot time.
 irods_enable_service: true
 
-# The max number of open files is only effective when
-# irods_service_type has been set to 'systemd'.
 irods_max_open_files: 131072

--- a/roles/irods_resource/tasks/main.yml
+++ b/roles/irods_resource/tasks/main.yml
@@ -5,28 +5,8 @@
   ansible.builtin.include_vars: "{{ ansible_os_family }}.yml"
 
 
-- name: Check iRODS service type is supported
-  ansible.builtin.fail:
-    msg: 'Error: irods_service_type value not supported'
-  when: irods_service_type not in ["sysv", "systemd"]
-
-
 - name: Populate service facts
   ansible.builtin.service_facts:
-
-
-- name: Stop iRODS service before switching between init systems
-  ansible.builtin.service:
-    name: irods
-    state: stopped
-  when: ((irods_service_type == "sysv" and
-          'irods.service' in services and
-          services['irods.service']['source'] == "systemd" and
-          services['irods.service']['state'] == "running")
-         or (irods_service_type == "systemd" and
-          'irods' in services and
-          services['irods']['source'] == "sysv" and
-          services['irods']['state'] == "running"))
 
 
 - name: Ensure systemd unit file present
@@ -37,33 +17,6 @@
     group: root
     mode: '0644'
   notify: Systemd daemon reload
-  when: irods_service_type == "systemd"
-
-
-- name: Ensure systemd unit file absent
-  ansible.builtin.file:
-    path: /lib/systemd/system/irods.service
-    state: absent
-  notify: Systemd daemon reload
-  when: irods_service_type == "sysv"
-
-
-- name: Flush handlers to trigger daemon reload after switching between init systems
-  ansible.builtin.meta: flush_handlers
-
-
-- name: Start iRODS service after switching between init systems
-  ansible.builtin.service:
-    name: irods
-    state: started
-  when: ((irods_service_type == "sysv" and
-          'irods.service' in services and
-          services['irods.service']['source'] == "systemd" and
-          services['irods.service']['state'] == "running")
-         or (irods_service_type == "systemd" and
-          'irods' in services and
-          services['irods']['source'] == "sysv" and
-          services['irods']['state'] == "running"))
 
 
 - name: Ensure iRODS resource server is installed
@@ -187,7 +140,6 @@
     name: irods
     enabled: "{{ irods_enable_service }}"
     use: service
-  when: irods_service_type == "systemd"
 
 
 - name: Wait until iRODS server is ready to receive requests


### PR DESCRIPTION
iRODS runs as a systemd service by default on Yoda servers, although SysV was still supported to decouple the switch to systemd from Yoda version upgrades. SysV support is no longer needed, because all servers use systemd now.