### PR TITLE
YDA-5616: upgrade SQLCipher data packages

### DIFF
--- a/roles/sqlcipher/tasks/install-ubuntu.yml
+++ b/roles/sqlcipher/tasks/install-ubuntu.yml
@@ -1,10 +1,35 @@
 ---
 # copyright Utrecht University
 
-- name: Ensure SQLCipher has been installed
+- name: Include OS-specific variables
+  ansible.builtin.include_vars: "{{ ansible_os_family }}.yml"
+
+
+# Ubuntu 20.04 LTS includes SQLCipher 3 by default. We need SQLCipher 4,
+# so that we can migrate token databases created on SQLCipher 4 to Ubuntu
+# 20.04 LTS servers.
+- name: Ensure standard SQLCipher packages are not installed
   ansible.builtin.package:
     name:
       - libsqlcipher0
       - sqlcipher
       - libsqlcipher-dev
+    state: absent
+
+
+- name: Download SQLCipher packages
+  ansible.builtin.get_url:
+    url: '{{ item.value.url }}'
+    dest: '{{ sqlcipher_package_dir }}/{{ item.value.filename }}'
+    checksum: '{{ item.value.checksum }}'
+    mode: '0644'
+  when: item.value.package not in ansible_facts.packages or item.value.version != ansible_facts.packages[item.value.package][0]['version']
+  with_dict: '{{ sqlcipher_packages }}'
+
+
+- name: Install SQLCipher from downloaded package files
+  ansible.builtin.apt:
+    deb: '{{ sqlcipher_package_dir }}/{{ item.value.filename }}'
     state: present
+  when: not ansible_check_mode and item.value.package not in ansible_facts.packages or item.value.version != ansible_facts.packages[item.value.package][0]['version']
+  with_dict: '{{ sqlcipher_packages }}'

--- a/roles/sqlcipher/vars/Debian.yml
+++ b/roles/sqlcipher/vars/Debian.yml
@@ -1,2 +1,25 @@
 ---
 # copyright Utrecht University
+
+# sqlcipher RPM locations and checksum
+sqlcipher_packages:
+  sqlcipher:
+    package: sqlcipher4
+    version: 4.5.6-1
+    url: https://yoda.uu.nl/packages-irods-4.2.12-focal/sqlcipher4.deb
+    filename: sqlcipher4.deb
+    checksum: sha256:5d113bb1b72756b3dcf2328ceb668b802b9c3406f4583bcc3544da3cef6b4679
+  sqlcipher_lib:
+    package: libsqlcipher4
+    version: 4.5.6-1
+    url: https://yoda.uu.nl/packages-irods-4.2.12-focal/libsqlcipher4.deb
+    filename: libsqlcipher4.deb
+    checksum: sha256:68ad31b7523a38975a35f9f33d37e0e94af1f3f663650d1be4e7e03f640a497e
+  sqlcipher_dev:
+    package: libsqlcipher4-dev
+    version: 4.5.6-1
+    url: https://yoda.uu.nl/packages-irods-4.2.12-focal/libsqlcipher4-dev.deb
+    filename: libsqlcipher4-dev.deb
+    checksum: sha256:814cdc08fad1c6644935cddd98466283da3a83bf42e62c1b11c13785a770fb15
+
+sqlcipher_package_dir: /tmp


### PR DESCRIPTION
Update SQLCipher packages on Ubuntu 20.04 LTS, so that we can migrate token databases from CentOS 7 servers (which use SQLite v4.x format) to Ubuntu servers.