### PR TITLE
YDA-5652: fix EUS Flask app session type

### DIFF
--- a/docker/images/yoda_eus/yoda_eus_init.sh
+++ b/docker/images/yoda_eus/yoda_eus_init.sh
@@ -112,6 +112,7 @@ YODA_EUS_FQDN       = 'eus.yoda'
 CSRF_TOKENS_ENABLED = 'true'
 API_SECRET          = 'PLACEHOLDER'
 EUS_TITLE_TEXT      = 'Yoda External User Service'
+SESSION_TYPE        = 'filesystem'
 
 # Theming configuration
 YODA_THEME_PATH     = '/var/www/yoda/themes' # Path to location of themes

--- a/roles/yoda_external_user_service/templates/flask.cfg.j2
+++ b/roles/yoda_external_user_service/templates/flask.cfg.j2
@@ -6,6 +6,7 @@ YODA_EUS_FQDN       = '{{ yoda_eus_fqdn }}'
 CSRF_TOKENS_ENABLED = 'true'
 API_SECRET          = '{{ eus_api_secret }}'
 EUS_TITLE_TEXT      = 'Yoda External User Service'
+SESSION_TYPE        = 'filesystem'
 
 # Theming configuration
 YODA_THEME_PATH     = '{{ yoda_theme_path }}' # Path to location of themes


### PR DESCRIPTION
The absence of this setting resulted in CSRF functionality failing to find the Flask secret key.