### PR TITLE
YDA-5651: add yoda_portal_upload_part_files option

### DIFF
--- a/docker/images/yoda_portal/yoda_portal_init.sh
+++ b/docker/images/yoda_portal/yoda_portal_init.sh
@@ -176,6 +176,8 @@ YODA_EUS_FQDN = 'eus.yoda.test'
 DATAREQUEST_HELP_CONTACT_NAME  = 'PLACEHOLDER'
 DATAREQUEST_HELP_CONTACT_EMAIL = 'PLACEHOLDER'
 
+UPLOAD_PART_FILES              = True
+
 # Text file extensions configuration
 TEXT_FILE_EXTENSIONS = ['bash', 'csv', 'c', 'cpp', 'csharp', 'css', 'diff', 'fortran', 'gams', 'gauss', 'go', 'graphql', 'ini', 'irpf90', 'java', 'js', 'json', 'julia', 'julia-repl', 'kotlin', 'less', 'lua', 'makefile', 'markdown', 'md', 'mathematica', 'matlab', 'maxima', 'mizar', 'objectivec', 'openscad', 'perl', 'php', 'php-template', 'plaintext', 'txt', 'python', 'py', 'python-repl', 'r', 'ruby', 'rust', 'sas', 'scilab', 'scss', 'shell', 'sh', 'sql', 'stan', 'stata', 'swift', 'typescript', 'ts', 'vbnet', 'wasm', 'xml', 'yaml', 'html']
 FLASKCFG

--- a/docs/administration/configuring-yoda.md
+++ b/docs/administration/configuring-yoda.md
@@ -156,6 +156,7 @@ yoda_theme_path                   | Path where themes for the Yoda Portal are re
 portal_session_cookie_samesite    | Samesite setting for session cookies Yoda Portal. Should be 'Lax' if OIDC is enabled and identity provider is in different domain. Otherwise it should be 'Strict'. Default value: 'Strict'.
 yoda_portal_wsgi_daemon_processes | The number of daemon processes that should be started in this process group (default: 1)
 yoda_portal_wsgi_daemon_threads   | The number of threads to be created to handle requests in each daemon process (default: 15)
+yoda_portal_upload_part_files     | Whether the portal uploader function should upload multi-chunk files as .part files initially and rename them to their final name later (boolean value, default: true). It is generally recommended to keep this enabled, so that users can easily see when an upload failed and the result is partial. However, on storage systems where renaming data objects takes much time, such as S3 object storage in consistent mode, it may be necessary to switch use of .part files off.
 
 ### Generic logging configuration
 

--- a/roles/yoda_portal/defaults/main.yml
+++ b/roles/yoda_portal/defaults/main.yml
@@ -47,6 +47,7 @@ portal_session_cookie_samesite: Strict             # 'Strict' (no OIDC, or OIDC 
 
 # Research module configuration
 enable_research: true                              # Enable research module
+yoda_portal_upload_part_files: true                # Allow use of .part data objects for the portal upload function
 
 # OpenSearch module configuration
 enable_open_search: false                          # Enable OpenSearch module

--- a/roles/yoda_portal/templates/flask.cfg.j2
+++ b/roles/yoda_portal/templates/flask.cfg.j2
@@ -103,5 +103,8 @@ YODA_EUS_FQDN = '{{ yoda_eus_fqdn | default("") }}'
 DATAREQUEST_HELP_CONTACT_NAME  = '{{ datarequest_help_contact_name }}'
 DATAREQUEST_HELP_CONTACT_EMAIL = '{{ datarequest_help_contact_email }}'
 
+# Upload function configuration
+UPLOAD_PART_FILES              = {{ yoda_portal_upload_part_files }}
+
 # Text file extensions configuration
 TEXT_FILE_EXTENSIONS = {{ text_file_extensions | default(['txt'])}}


### PR DESCRIPTION
So that initially using .part data object names for files that are being uploaded becomes optional.