### PR TITLE
Add custom DNS server config options

### DIFF
--- a/docs/administration/configuring-yoda.md
+++ b/docs/administration/configuring-yoda.md
@@ -131,6 +131,9 @@ ansible_ssh_private_key_file | Path to private key file of administrative user
 repo_only                    | Only download packages from repos
 centos_extras_repository     | Name of the CentOS extras repository
 centos_sclo_rh_repository    | Name of the CentOS SCLO-RH repository
+common_custom_dns_enable     | Set custom DNS servers (default: false, only supported only on Ubuntu)
+common_custom_dns_primary    | Primary custom DNS server (default: Google DNS servers, only supported on Ubuntu)
+common_custom_dns_secondary  | Secondary custom DNS server (default: Google DNS servers, only supported on Ubuntu)
 
 Note: if one of these variables are different for a host then define them in the corresponding host specific variables file (host_vars).
 

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -5,3 +5,7 @@ tcp_keepalive_time: 7200
 tcp_keepalive_intvl: 75
 
 commons_default_umask: "0027"
+
+common_custom_dns_enable: false
+common_custom_dns_primary: 8.8.8.8
+common_custom_dns_secondary: 8.8.4.4

--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -6,5 +6,12 @@
     name: firewalld
     state: restarted
 
+
+- name: Restart systemd-resolved
+  ansible.builtin.service:
+    name: systemd-resolved
+    state: restarted
+
+
 - name: Reset Ansible connection
   ansible.builtin.meta: reset_connection

--- a/roles/common/tasks/custom_dns.yml
+++ b/roles/common/tasks/custom_dns.yml
@@ -1,0 +1,15 @@
+---
+# copyright Utrecht University
+
+- name: Update systemd-resolved config to use Google DNS servers
+  ansible.builtin.template:
+    src: resolved.conf.j2
+    dest: /etc/systemd/resolved.conf
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart systemd-resolved
+
+
+- name: Flush handlers for immediate effect of changing DNS configuration
+  ansible.builtin.meta: flush_handlers

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -4,6 +4,10 @@
 - name: Setup hostname
   ansible.builtin.import_tasks: hostname.yml
 
+- name: Update local DNS settings
+  ansible.builtin.import_tasks: custom_dns.yml
+  when: common_use_custom_dns and ansible_os_family == 'Debian'
+
 - name: Setup EPEL repository
   ansible.builtin.import_tasks: epel.yml
   when: ansible_os_family == 'RedHat'

--- a/roles/common/templates/resolved.conf.j2
+++ b/roles/common/templates/resolved.conf.j2
@@ -1,0 +1,25 @@
+# {{ ansible_managed }}
+##  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+#
+# Entries in this file show the compile time defaults.
+# You can change settings by editing this file.
+# Defaults can be restored by simply deleting this file.
+#
+# See resolved.conf(5) for details
+
+[Resolve]
+DNS={{ common_custom_dns_primary }}
+FallbackDNS={{ common_custom_dns_secondary }}
+#Domains=
+#LLMNR=no
+#MulticastDNS=no
+#DNSSEC=no
+#DNSOverTLS=no
+#Cache=no-negative
+#DNSStubListener=yes
+#ReadEtcHosts=yes


### PR DESCRIPTION
To be used for development VMs where the default DNS setup is flaky.