### PR TITLE
YDA-5713: restrict access to iRODS anon. account

### DIFF
--- a/docker/images/yoda_irods_icat/rules_uu.cfg
+++ b/docker/images/yoda_irods_icat/rules_uu.cfg
@@ -79,6 +79,8 @@ arb_exempt_resources            = ''
 arb_min_gb_free                 = '0'
 arb_min_percent_free            = '0'
 
+remote_anonymous_access         = ''
+
 text_file_extensions            = 'bash csv c cpp csharp css diff fortran gams gauss go graphql ini irpf90 java js json julia julia-repl kotlin less lua makefile markdown md mathematica matlab maxima mizar objectivec openscad perl php php-template plaintext txt python py python-repl r ruby rust sas scilab scss shell sh sql stan stata swift typescript ts vbnet wasm xml yaml html'
 vault_copy_multithread_enabled  = 'true'
 python3_interpreter             = '/usr/bin/python3'

--- a/docs/administration/configuring-yoda.md
+++ b/docs/administration/configuring-yoda.md
@@ -198,6 +198,7 @@ irods_rum_job_minute                 | Time to run RUM job - minute (default: 0)
 irods_enable_gocommands              | Whether to install the GoCommands CLI (disabled by default)
 irods_gocommands_version             | GoCommands version
 irods_gocommands_archive_checksum    | MD5 checksum of the GoCommands archive for the version to be installed
+irods_anonymous_account_permit_addresses  | List of network addresses that can log in on the anonymous account using the iRODS protocol. Localhost (127.0.0.1) is always allowed.
 
 ### S3 configuration - for iRODS S3 resource plugin and s3cmd utilities
 

--- a/docs/release-notes/release-1.10.md
+++ b/docs/release-notes/release-1.10.md
@@ -22,6 +22,10 @@ Version constraints:
 * Requires Yoda external user service to be on version 1.9.x or higher.
 * Requires Yoda public server to be on version 1.9.x or higher.
 
+Configuration changes:
+* Yoda 1.10 blocks remote access to the anonymous account via the iRODS protocol by default. If you run DavRODS on a different server from the provider, you need to add
+  its network address to the `irods_anonymous_account_permit_addresses` configuration parameter.
+
 1. Backup/copy custom configurations made to Yoda version 1.9.
 To view what files were changed from the defaults, run `git diff`.
 

--- a/environments/development/full/group_vars/full.yml
+++ b/environments/development/full/group_vars/full.yml
@@ -87,6 +87,7 @@ irods_database_fqdn: database.yoda.test    # iRODS database fully qualified doma
 irods_resource_fqdn: resource.yoda.test    # iRODS resource fully qualified domain name (FQDN)
 irods_ssl_verify_server: none              # Verify TLS certificate, use 'cert' for acceptance and production
 irods_enable_gocommands: false
+irods_anonymous_account_permit_addresses: ['192.168.56.10']
 irods_resources:
   - name: dev001_1
     host: "{{ irods_icat_fqdn }}"

--- a/environments/development/surf/group_vars/surf.yml
+++ b/environments/development/surf/group_vars/surf.yml
@@ -87,6 +87,7 @@ irods_database_fqdn: portal.surfyoda.test    # iRODS database fully qualified do
 # irods_resource_fqdn: resource.surfyoda.test # iRODS resource fully qualified domain name (FQDN)
 irods_ssl_verify_server: none                # Verify TLS certificate, use 'cert' for acceptance and production
 irods_enable_gocommands: false
+irods_anonymous_account_permit_addresses: ['192.168.56.21']
 irods_resources:
   - name: dev001_1
     host: "{{ yoda_davrods_fqdn }}"

--- a/roles/yoda_rulesets/defaults/main.yml
+++ b/roles/yoda_rulesets/defaults/main.yml
@@ -204,6 +204,8 @@ irods_arb_exempt_resources: ""
 irods_arb_min_gb_free: 0
 irods_arb_min_percent_free: 5
 
+irods_anonymous_account_permit_addresses: []
+
 # Text file extensions configuration
 text_file_extensions: ['bash', 'csv', 'c', 'cpp', 'csharp', 'css', 'diff', 'fortran', 'gams', 'gauss', 'go', 'graphql', 'ini', 'irpf90', 'java', 'js', 'json', 'julia', 'julia-repl', 'kotlin', 'less', 'lua', 'makefile', 'markdown', 'md', 'mathematica', 'matlab', 'maxima', 'mizar', 'objectivec', 'openscad', 'perl', 'php', 'php-template', 'plaintext', 'txt', 'python', 'py', 'python-repl', 'r', 'ruby', 'rust', 'sas', 'scilab', 'scss', 'shell', 'sh', 'sql', 'stan', 'stata', 'swift', 'typescript', 'ts', 'vbnet', 'wasm', 'xml', 'yaml', 'html']
 

--- a/roles/yoda_rulesets/templates/rules_uu.cfg.j2
+++ b/roles/yoda_rulesets/templates/rules_uu.cfg.j2
@@ -106,6 +106,8 @@ arb_exempt_resources           = '{{ irods_arb_exempt_resources }}'
 arb_min_gb_free                = '{{ irods_arb_min_gb_free }}'
 arb_min_percent_free           = '{{ irods_arb_min_percent_free }}'
 
+remote_anonymous_access        = '{{ irods_anonymous_account_permit_addresses | join (" ") }}'
+
 text_file_extensions           = '{{ text_file_extensions | join (" ") }}'
 vault_copy_multithread_enabled = '{{ ["false", "true"][yoda_rulesets_vault_copy_multithread_enabled|int] }}'
 notifications_enabled          = '{{ ["false", "true"][send_notifications|int] }}'


### PR DESCRIPTION
Add parameter for specifying which remote network addresses can log in on the iRODS anonymous account. By default, only local access is allowed.