### PR TITLE
Yda 5699 add admin page, add new group priv-admin and its' first member

### DIFF
--- a/roles/yoda_rulesets/tasks/yoda-ruleset.yml
+++ b/roles/yoda_rulesets/tasks/yoda-ruleset.yml
@@ -14,7 +14,7 @@
   become: true
   ansible.builtin.command: 'iadmin lg'
   register: priv_groups
-  changed_when: priv_groups.stdout.find('priv-group-add') == -1
+  changed_when: priv_groups.stdout.find('priv-admin') == -1
   check_mode: false
 
 
@@ -23,7 +23,7 @@
   become: true
   ansible.builtin.command: # noqa no-changed-when
     cmd: '/etc/irods/yoda-ruleset/tools/group-manager-setup.sh'
-  when: priv_groups.stdout.find('priv-group-add') == -1
+  when: priv_groups.stdout.find('priv-admin') == -1
 
 
 - name: Find out which system collections are present

--- a/roles/yoda_test/defaults/main.yml
+++ b/roles/yoda_test/defaults/main.yml
@@ -94,7 +94,6 @@ test_group_users:
   - {groupName: priv-group-add, user: functionaladmingroup,           role: manager}
 
   - {groupName: priv-admin, user: functionaladminpriv,               role: manager}
-  - {groupName: priv-category-add, user: functionaladmincategory,           role: manager}
 
   - {groupName: research-initial, user: viewer,                        role: reader}
   - {groupName: research-initial, user: researcher,                    role: normal}

--- a/roles/yoda_test/defaults/main.yml
+++ b/roles/yoda_test/defaults/main.yml
@@ -93,6 +93,8 @@ test_group_users:
   - {groupName: priv-group-add, user: functionaladminpriv,            role: manager}
   - {groupName: priv-group-add, user: functionaladmingroup,           role: manager}
 
+  - {groupName: priv-admin, user: functionaladminpriv,               role: manager}
+
   - {groupName: research-initial, user: viewer,                        role: reader}
   - {groupName: research-initial, user: researcher,                    role: normal}
   - {groupName: research-initial, user: groupmanager,                  role: manager}

--- a/roles/yoda_test/defaults/main.yml
+++ b/roles/yoda_test/defaults/main.yml
@@ -94,6 +94,7 @@ test_group_users:
   - {groupName: priv-group-add, user: functionaladmingroup,           role: manager}
 
   - {groupName: priv-admin, user: functionaladminpriv,               role: manager}
+  - {groupName: priv-category-add, user: functionaladmincategory,           role: manager}
 
   - {groupName: research-initial, user: viewer,                        role: reader}
   - {groupName: research-initial, user: researcher,                    role: normal}


### PR DESCRIPTION
Added new group priv-admin and its first member funcitonaladminpriv.

The new codes have been tested through deployment, e.g., deployed to my local VMs. 

See the main PR from ruleset-repo https://github.com/UtrechtUniversity/yoda-ruleset/pull/443