### PR TITLE
YDA-5827: ensure securecopy present on consumer

### DIFF
--- a/roles/irods_resource/tasks/main.yml
+++ b/roles/irods_resource/tasks/main.yml
@@ -279,3 +279,35 @@
     - key: 'negotiation_key'
       value: "{{ irods_negotiation_key }}"
   when: not ansible_check_mode
+
+
+- name: Ensure iRODS .ssh directory has strict permissions
+  become_user: '{{ irods_service_account }}'
+  become: true
+  ansible.builtin.file:
+    path: ~/.ssh
+    state: directory
+    mode: '0700'
+    owner: '{{ irods_service_account }}'
+    group: '{{ irods_service_account }}'
+
+
+- name: Install private upload key
+  become_user: '{{ irods_service_account }}'
+  become: true
+  ansible.builtin.template:
+    src: id_ed25519.j2
+    dest: '~/.ssh/id_ed25519'
+    owner: '{{ irods_service_account }}'
+    mode: '0600'
+  no_log: true
+  when: upload_priv_key is defined
+
+
+- name: Scan public host pub key
+  become_user: '{{ irods_service_account }}'
+  become: true
+  ansible.builtin.shell: "ssh-keyscan {{ yoda_public_host }} >> ~/.ssh/known_hosts"
+  args:
+    creates: '~/.ssh/known_hosts'
+  when: upload_priv_key is defined

--- a/roles/irods_resource/templates/id_ed25519.j2
+++ b/roles/irods_resource/templates/id_ed25519.j2
@@ -1,0 +1,1 @@
+{{ upload_priv_key | b64decode }}

--- a/roles/yoda_rulesets/tasks/main.yml
+++ b/roles/yoda_rulesets/tasks/main.yml
@@ -159,6 +159,17 @@
     mode: '0644'
 
 
+- name: Copy securecopy script to ExecCmd dir
+  become_user: "{{ irods_service_account }}"
+  become: true
+  ansible.builtin.copy:
+    remote_src: true
+    src: "/etc/irods/yoda-ruleset/tools/securecopy.sh"
+    dest: "/var/lib/irods/msiExecCmd_bin/securecopy.sh"
+    mode: '0755'
+  when: not ansible_check_mode
+
+
 - name: Install Yoda rulesets
   ansible.builtin.include_tasks: "{{ ruleset.name }}.yml"
   with_items: "{{ extra_rulesets + core_rulesets }}"

--- a/roles/yoda_rulesets/tasks/yoda-ruleset.yml
+++ b/roles/yoda_rulesets/tasks/yoda-ruleset.yml
@@ -93,7 +93,6 @@
     mode: '0755'
   when: not ansible_check_mode
   with_items:
-    - securecopy.sh
     - scheduled-copytovault.sh
     - admin-remove-orphan-vault-if-empty.sh
     - admin-vaultactions.sh


### PR DESCRIPTION
In environments with a separate consumer server, we need to ensure that the securecopy.sh script is present on the consumer as well, since the publication code ultimately uses msiExecCmd to resolve landing page and combi JSON data objects to a local file. If it resolves one of these data objects to a replica on the consumer, it will try to run securecopy from there.

In order to be able to run the securecopy script, we also need to install the SSH key for copying files to the public server.