### PR TITLE
YDA-5831: add param for Apache duration logging

### DIFF
--- a/docker/images/davrods/apache2.conf
+++ b/docker/images/davrods/apache2.conf
@@ -216,7 +216,7 @@ AccessFileName .htaccess
     #
 
     LogFormat "%{X-Forwarded-For}i %h %l %u %v %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
-    LogFormat "%{X-Forwarded-For}i %h %l %u %v %t \"%r\" %>s %b" common
+    LogFormat "%{X-Forwarded-For}i %h %l %u %v %t \"%r\" %>s %b %D(%T)" common
 
     <IfModule logio_module>
       # You need to enable mod_logio.c to use %I and %O

--- a/docker/images/yoda_eus/apache2.conf
+++ b/docker/images/yoda_eus/apache2.conf
@@ -216,7 +216,7 @@ AccessFileName .htaccess
     #
 
     LogFormat "%{X-Forwarded-For}i %h %l %u %v %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
-    LogFormat "%{X-Forwarded-For}i %h %l %u %v %t \"%r\" %>s %b" common
+    LogFormat "%{X-Forwarded-For}i %h %l %u %v %t \"%r\" %>s %b %D(%T)" common
 
     <IfModule logio_module>
       # You need to enable mod_logio.c to use %I and %O

--- a/docker/images/yoda_portal/apache2.conf
+++ b/docker/images/yoda_portal/apache2.conf
@@ -216,7 +216,7 @@ AccessFileName .htaccess
     #
 
     LogFormat "%{X-Forwarded-For}i %h %l %u %v %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
-    LogFormat "%{X-Forwarded-For}i %h %l %u %v %t \"%r\" %>s %b" common
+    LogFormat "%{X-Forwarded-For}i %h %l %u %v %t \"%r\" %>s %b %D(%T)" common
 
     <IfModule logio_module>
       # You need to enable mod_logio.c to use %I and %O

--- a/docker/images/yoda_public/apache2.conf
+++ b/docker/images/yoda_public/apache2.conf
@@ -216,7 +216,7 @@ AccessFileName .htaccess
     #
 
     LogFormat "%{X-Forwarded-For}i %h %l %u %v %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
-    LogFormat "%{X-Forwarded-For}i %h %l %u %v %t \"%r\" %>s %b" common
+    LogFormat "%{X-Forwarded-For}i %h %l %u %v %t \"%r\" %>s %b %D(%T)" common
 
     <IfModule logio_module>
       # You need to enable mod_logio.c to use %I and %O

--- a/docker/images/yoda_web_mock/apache2.conf
+++ b/docker/images/yoda_web_mock/apache2.conf
@@ -216,7 +216,7 @@ AccessFileName .htaccess
     #
 
     LogFormat "%{X-Forwarded-For}i %h %l %u %v %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
-    LogFormat "%{X-Forwarded-For}i %h %l %u %v %t \"%r\" %>s %b" common
+    LogFormat "%{X-Forwarded-For}i %h %l %u %v %t \"%r\" %>s %b %D(%T)" common
 
     <IfModule logio_module>
       # You need to enable mod_logio.c to use %I and %O

--- a/docs/administration/configuring-yoda.md
+++ b/docs/administration/configuring-yoda.md
@@ -166,6 +166,7 @@ Variable                           | Description
 -----------------------------------|---------------------------------------------
 httpd_log_forwarded_for            | Whether to log X-Forwarded-For headers in Apache logs (boolean, default value: false). This logs source IP addresses of requests if requests to the Yoda web portal and/or WebDAV interface are routed via a load balancer.
 httpd_log_user_agent               | Whether to log the user agent of browsers and WebDAV clients in the Apache logs (boolean, default value: false)
+httpd_log_request_duration         | Whether to log how much time it took to respond to web server requests (boolean, default value: false). Time is logged in both microseconds, and in seconds (rounded down).
 yoda_portal_log_api_call_duration  | Whether to log duration and parameters of all API calls from the Yoda portal. This is mainly useful for performance testing (boolean, default value: false)
 
 

--- a/roles/apache/defaults/main.yml
+++ b/roles/apache/defaults/main.yml
@@ -3,3 +3,4 @@
 yoda_enable_httpd: true
 httpd_log_forwarded_for: false
 httpd_log_user_agent: false
+httpd_log_request_duration: false

--- a/roles/apache/templates/main.conf.el7.j2
+++ b/roles/apache/templates/main.conf.el7.j2
@@ -180,8 +180,9 @@ LogLevel warn
 
     {% set httpd_log_forwarded_for_fragment = "%{X-Forwarded-For}i " if httpd_log_forwarded_for else "" -%}
     {%- set httpd_log_user_agent_fragment = ' \\"%{User-Agent}i\\"' if httpd_log_user_agent else "" -%}
+    {%- set httpd_log_request_duration_fragment = " %D(%T)" if httpd_log_request_duration else "" -%}
     LogFormat "{{ httpd_log_forwarded_for_fragment }}%h %l %u %v %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
-    LogFormat "{{ httpd_log_forwarded_for_fragment }}%h %l %u %v %t \"%r\" %>s %b {{ httpd_log_user_agent_fragment }}" common
+    LogFormat "{{ httpd_log_forwarded_for_fragment }}%h %l %u %v %t \"%r\" %>s %b {{ httpd_log_user_agent_fragment }}{{ httpd_log_request_duration_fragment }}" common
 
     <IfModule logio_module>
       # You need to enable mod_logio.c to use %I and %O

--- a/roles/apache/templates/main.conf.focal.j2
+++ b/roles/apache/templates/main.conf.focal.j2
@@ -218,8 +218,9 @@ AccessFileName .htaccess
 
     {% set httpd_log_forwarded_for_fragment = "%{X-Forwarded-For}i " if httpd_log_forwarded_for else "" -%}
     {%- set httpd_log_user_agent_fragment = ' \\"%{User-Agent}i\\"' if httpd_log_user_agent else "" -%}
+    {%- set httpd_log_request_duration_fragment = " %D(%T)" if httpd_log_request_duration else "" -%}
     LogFormat "{{ httpd_log_forwarded_for_fragment }}%h %l %u %v %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
-    LogFormat "{{ httpd_log_forwarded_for_fragment }}%h %l %u %v %t \"%r\" %>s %b {{ httpd_log_user_agent_fragment }}" common
+    LogFormat "{{ httpd_log_forwarded_for_fragment }}%h %l %u %v %t \"%r\" %>s %b {{ httpd_log_user_agent_fragment }}{{ httpd_log_request_duration_fragment }}" common
 
     <IfModule logio_module>
       # You need to enable mod_logio.c to use %I and %O


### PR DESCRIPTION
Add parameter to enable duration logging of web requests in Apache. This can be used for performance monitoring, as well as troubleshooting performance issues.