### PR TITLE
fix uninstalled package

### DIFF
--- a/roles/irods_icat/tasks/setup_pam.yml
+++ b/roles/irods_icat/tasks/setup_pam.yml
@@ -56,7 +56,7 @@
     state: present
     extra_args: "--user --ignore-installed"
   become: true
-  become_user: irods
+  become_user: "{{ irods_service_account }}"
   when: enable_tokens
 
 

--- a/roles/irods_icat/tasks/setup_pam.yml
+++ b/roles/irods_icat/tasks/setup_pam.yml
@@ -46,7 +46,17 @@
     name: pysqlcipher3==1.0.4
     executable: "{{ irods_icat_pip2_path }}"
     state: present
+  when: enable_tokens
+
+
+- name: Ensure pysqlcipher3 is installed globally for token authentication script
+  ansible.builtin.pip:
+    name: pysqlcipher3==1.0.4
+    executable: "{{ irods_icat_pip2_path }}"
+    state: present
     extra_args: "--user --ignore-installed"
+  become: true
+  become_user: irods
   when: enable_tokens
 
 

--- a/roles/irods_icat/tasks/setup_pam.yml
+++ b/roles/irods_icat/tasks/setup_pam.yml
@@ -49,7 +49,7 @@
   when: enable_tokens
 
 
-- name: Ensure pysqlcipher3 is installed globally for token authentication script
+- name: Ensure pysqlcipher3 is installed for irods user locally
   ansible.builtin.pip:
     name: pysqlcipher3==1.0.4
     executable: "{{ irods_icat_pip2_path }}"

--- a/roles/irods_icat/tasks/setup_pam.yml
+++ b/roles/irods_icat/tasks/setup_pam.yml
@@ -46,7 +46,7 @@
     name: pysqlcipher3==1.0.4
     executable: "{{ irods_icat_pip2_path }}"
     state: present
-    extra_args: "--ignore-installed"
+    extra_args: "--user --ignore-installed"
   when: enable_tokens
 
 

--- a/roles/irods_icat/tasks/setup_pam.yml
+++ b/roles/irods_icat/tasks/setup_pam.yml
@@ -46,6 +46,7 @@
     name: pysqlcipher3==1.0.4
     executable: "{{ irods_icat_pip2_path }}"
     state: present
+    extra_args: "--ignore-installed"
   when: enable_tokens
 
 


### PR DESCRIPTION
**Problem:**
The following error is showing when trying to run the tools/list-data-access-tokens.py in yoda_ruleset
```
  File "<stdin>", line 1, in <module>

  File "/usr/local/lib/python2.7/dist-packages/pysqlcipher3/dbapi2.py", line 31, in <module>
    from pysqlcipher3._sqlite import *
ImportError: /usr/local/lib/python2.7/dist-packages/pysqlcipher3/_sqlite.so: undefined symbol: OpenSSL_version
```

**Solution**
We add to the specific task which installed the pysqlcipher3 the option to install the missing package for pysqlcipher3, so now the tools/list-data-access-tokens.py  in yoda_ruleset.