### PR TITLE
YDA-5985: fix interpreter path ARB update script

### DIFF
--- a/roles/irods_arb/tasks/main.yml
+++ b/roles/irods_arb/tasks/main.yml
@@ -11,7 +11,7 @@
     name: 'arb-update-resources.py'
     minute: '*'
     hour: '*'
-    job: '/usr/local/bin/python3 /etc/irods/yoda-ruleset/tools/arb-update-resources.py > /dev/null'
+    job: '/usr/bin/python3 /etc/irods/yoda-ruleset/tools/arb-update-resources.py > /dev/null'
     state: '{{ "present" if irods_arb_enabled else "absent" }}'
 
 


### PR DESCRIPTION
Needed to be updated for Ubuntu 20.04 LTS