### PR TITLE
YDA-5986: fix intake vault cronjob error

### DIFF
--- a/roles/yoda_rulesets/tasks/yoda-ruleset.yml
+++ b/roles/yoda_rulesets/tasks/yoda-ruleset.yml
@@ -454,7 +454,7 @@
   ansible.builtin.cron:
     name: 'job_movetovault.r'
     minute: '*/5'
-    job: '{{ irods_directory.stdout }}/.irods/run-intake-movetovault.sh >& /dev/null'
+    job: '{{ irods_directory.stdout }}/.irods/run-intake-movetovault.sh >/dev/null 2>&1'
     state: '{{ "present" if enable_intake else "absent" }}'
 
 


### PR DESCRIPTION
The intake-to-vault cronjob was not running correctly because it used bash/csh style redirects. Replace it with traditional Bourne shell redirects, so that cron can run it with the Ubuntu default shell (Dash).