### PR TITLE
YDA-6002: Adjust Apache2 AppArmor profile

### DIFF
--- a/roles/apache/templates/usr.sbin.apache2.j2
+++ b/roles/apache/templates/usr.sbin.apache2.j2
@@ -40,6 +40,7 @@
   /var/log/apache2/*.log w,
   /var/www/landingpages/** r,
   /var/www/yoda/** r,
+  owner /dev/shm/* mrwl,
   owner /etc/apache2/** r,
   owner /home/yodadeployment/flask_session/ r,
   owner /home/yodadeployment/flask_session/* rw,


### PR DESCRIPTION
Adjust Apache2 AppArmor profile for portal Werkzeug upgrade from version 3.0.3 to 3.0.6

Portal PR https://github.com/UtrechtUniversity/yoda-portal/pull/371 depends on this PR