### PR TITLE
YDA-6045: fix Apache global TLS configuration

### DIFF
--- a/roles/apache/files/ports.conf.focal
+++ b/roles/apache/files/ports.conf.focal
@@ -1,0 +1,10 @@
+# If you just change the port or add more ports here, you will likely also
+# have to change the VirtualHost statement in
+# /etc/apache2/sites-enabled/000-default.conf
+
+Listen 80
+
+# Listen statements for ports 443 and 8443 are in SSL module configuration and the
+# EUS vhost file.
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/roles/apache/tasks/main-tasks.yml
+++ b/roles/apache/tasks/main-tasks.yml
@@ -58,6 +58,16 @@
   when: ansible_os_family == 'Debian'
 
 
+- name: Copy Apache ports configuration file (Ubuntu)
+  ansible.builtin.copy:
+    src: ports.conf.focal
+    dest: /etc/apache2/ports.conf
+    owner: root
+    group: root
+    mode: '0644'
+  when: ansible_os_family == 'Debian'
+
+
 - name: Ensure autoindex.conf is absent
   ansible.builtin.file:
     path: '{{ item }}'
@@ -89,6 +99,16 @@
   with_items:
     - headers
     - ssl
+    - socache_shmcb
+  when: ansible_os_family == 'Debian'
+
+
+- name: Ensure Apache global SSL configuration is loaded (Ubuntu)
+  ansible.builtin.file:
+    src: "/etc/apache2/mods-available/ssl.conf"
+    dest: "/etc/apache2/mods-enabled/ssl.conf"
+    state: link
+  notify: Restart Apache webserver
   when: ansible_os_family == 'Debian'
 
 


### PR DESCRIPTION
The Apache global TLS configuration was not applied on Ubuntu 20.04 LTS, which resulted in the session cache not being created.

This change activates the global TLS configuration, including the configuration of the session cache, so that we have session resumption. We also needed to re-arrange Listen statements for TCP ports to ensure each port has at most one Listen statement