### PR TITLE
YDA-5994: modify Postfix role to allow queue cmd

### DIFF
--- a/roles/postfix/handlers/main.yml
+++ b/roles/postfix/handlers/main.yml
@@ -8,6 +8,12 @@
   when: not ansible_check_mode
 
 
+- name: Reload Apparmor
+  ansible.builtin.service:
+    name: apparmor
+    state: reloaded
+
+
 - name: Systemd daemon reload
   ansible.builtin.systemd:
     daemon_reload: true

--- a/roles/postfix/tasks/main.yml
+++ b/roles/postfix/tasks/main.yml
@@ -180,6 +180,7 @@
     - usr.sbin.postalias
     - usr.sbin.sendmail.postfix
   register: postfix_apparmor_default
+  notify: Reload Apparmor
   when: not ansible_check_mode and ansible_os_family == "Debian"
 
 
@@ -202,6 +203,7 @@
     - src: 'usr.sbin.sendmail.j2'
       dest: 'usr.sbin.sendmail'
   register: postfix_apparmor_custom
+  notify: Reload Apparmor
   when: ansible_os_family == "Debian"
 
 

--- a/roles/postfix/templates/usr.sbin.postfix.j2
+++ b/roles/postfix/templates/usr.sbin.postfix.j2
@@ -1,5 +1,5 @@
 # {{ ansible_managed }}
-# Last Modified: Tue Oct 22 15:17:36 2024
+# Last Modified: Mon Dec  9 14:18:33 2024
 #include <tunables/global>
 
 # vim:syntax=apparmor
@@ -24,6 +24,7 @@
   signal send set=term peer=/usr/sbin/postfix//null-/usr/lib/postfix/sbin/pickup,
   signal send set=term peer=/usr/sbin/postfix//null-/usr/lib/postfix/sbin/qmgr,
   signal send set=term peer=/usr/sbin/postfix//null-/usr/lib/postfix/sbin/scache,
+  signal send set=term peer=/usr/sbin/postfix//null-/usr/lib/postfix/sbin/showq,
   signal send set=term peer=/usr/sbin/postfix//null-/usr/lib/postfix/sbin/smtp,
   signal send set=term peer=/usr/sbin/postfix//null-/usr/lib/postfix/sbin/tlsmgr,
   signal send set=term peer=/usr/sbin/postfix//null-/usr/lib/postfix/sbin/trivial-rewrite,
@@ -69,6 +70,7 @@
   owner /etc/postfix/postfix-files.d/ r,
   owner /etc/postfix/sasl/ r,
   owner /usr/sbin/sendmail r,
+  owner /var/lib/postfix/__db.smtp_scache.db rw,
   owner /var/lib/postfix/master.lock rwk,
   owner /var/lib/postfix/prng_exch k,
   owner /var/lib/postfix/prng_exch rw,

--- a/roles/postfix/templates/usr.sbin.postqueue.j2
+++ b/roles/postfix/templates/usr.sbin.postqueue.j2
@@ -1,5 +1,5 @@
 # {{ ansible_managed }}
-# Last Modified: Tue Oct 22 13:36:14 2024
+# Last Modified: Mon Dec  9 14:13:02 2024
 #include <tunables/global>
 
 # ------------------------------------------------------------------
@@ -31,8 +31,8 @@
   /var/spool/postfix/maildrop r,
   /var/spool/postfix/maildrop/* rwl,
   /var/spool/postfix/pid r,
-  /var/spool/postfix/public/pickup w,
-  /var/spool/postfix/public/qmgr w,
+  /var/spool/postfix/public/pickup rw,
+  /var/spool/postfix/public/qmgr rw,
   /var/spool/postfix/public/showq rw,
 
 }


### PR DESCRIPTION
Modify the Postfix role to ensure that the AppArmor profile allows viewing and flushing the mail queue using the postqueue command. Also ensure that any AppArmor profile changes will be reloaded after modifications.

A part of the issue was already fixed before in the changes for ticket YDA-5971.