### PR TITLE
bug fix: add optional anasible task to enable custmized DNS (EL9)

### DIFF
--- a/roles/common/tasks/custom_dns.yml
+++ b/roles/common/tasks/custom_dns.yml
@@ -12,8 +12,9 @@
   when: ansible_os_family == 'Debian'
 
 
-- name: Configure /etc/resolv.conf via Ansible (EL9)
-  become: true  
+- name: Update resolv.conf to use Google DNS servers (EL9)
+  become: true
+  when: ansible_os_family == 'RedHat'
   block:
     - name: Create manually configured DNS settings file
       ansible.builtin.copy:
@@ -36,8 +37,7 @@
         src: /etc/resolv.conf.manually-configured
         dest: /etc/resolv.conf
         state: link
-        force: yes
-  when: ansible_os_family == 'RedHat'
+        force: true
 
 - name: Flush handlers for immediate effect of changing DNS configuration
   ansible.builtin.meta: flush_handlers

--- a/roles/common/tasks/custom_dns.yml
+++ b/roles/common/tasks/custom_dns.yml
@@ -1,7 +1,7 @@
 ---
 # copyright Utrecht University
 
-- name: Update systemd-resolved config to use Google DNS servers
+- name: Update systemd-resolved config to use Google DNS servers (Ubuntu)
   ansible.builtin.template:
     src: resolved.conf.j2
     dest: /etc/systemd/resolved.conf
@@ -9,7 +9,35 @@
     group: root
     mode: "0644"
   notify: Restart systemd-resolved
+  when: ansible_os_family == 'Debian'
 
+
+- name: Configure /etc/resolv.conf via Ansible (EL9)
+  become: true  
+  block:
+    - name: Create manually configured DNS settings file
+      ansible.builtin.copy:
+        dest: /etc/resolv.conf.manually-configured
+        content: |
+          search yoda.test
+          nameserver {{ common_custom_dns_primary }}
+          nameserver {{ common_custom_dns_secondary }}
+        owner: root
+        group: root
+        mode: '0644'
+
+    - name: Remove existing /etc/resolv.conf
+      ansible.builtin.file:
+        path: /etc/resolv.conf
+        state: absent
+
+    - name: Create symlink for /etc/resolv.conf
+      ansible.builtin.file:
+        src: /etc/resolv.conf.manually-configured
+        dest: /etc/resolv.conf
+        state: link
+        force: yes
+  when: ansible_os_family == 'RedHat'
 
 - name: Flush handlers for immediate effect of changing DNS configuration
   ansible.builtin.meta: flush_handlers

--- a/roles/common/tasks/main-tasks.yml
+++ b/roles/common/tasks/main-tasks.yml
@@ -6,7 +6,7 @@
 
 - name: Update local DNS settings
   ansible.builtin.import_tasks: custom_dns.yml
-  when: common_custom_dns_enable and ansible_os_family == 'Debian'
+  when: common_custom_dns_enable 
 
 - name: Setup EPEL repository
   ansible.builtin.import_tasks: epel.yml

--- a/roles/common/tasks/main-tasks.yml
+++ b/roles/common/tasks/main-tasks.yml
@@ -6,7 +6,7 @@
 
 - name: Update local DNS settings
   ansible.builtin.import_tasks: custom_dns.yml
-  when: common_custom_dns_enable 
+  when: common_custom_dns_enable
 
 - name: Setup EPEL repository
   ansible.builtin.import_tasks: epel.yml


### PR DESCRIPTION
To test the deployment, ensure using the Alma9 Vagrant file and enable `common_custom_dns_enable`