### PR TITLE
YDA-6256: Set EUS flask.cfg group to yodadeployment

### DIFF
--- a/roles/yoda_external_user_service/tasks/main.yml
+++ b/roles/yoda_external_user_service/tasks/main.yml
@@ -182,6 +182,7 @@
     src: flask.cfg.j2
     dest: /var/www/extuser/flask.cfg
     owner: "{{ yoda_deployment_user }}"
+    group: "{{ yoda_deployment_user }}"
     mode: '0644'
   when: not ansible_check_mode
   notify: Restart Apache webserver


### PR DESCRIPTION
This better matches the flask.cfg configuration of the portal. It appears to reduce some errors in the logs as well.

Before, the group owner of the file was listed as root.