### PR TITLE
YDA-6314 Add ruleset code coverage measurement

### DIFF
--- a/docker/images/yoda_irods_icat/rules_uu.cfg
+++ b/docker/images/yoda_irods_icat/rules_uu.cfg
@@ -86,3 +86,5 @@ user_max_connections_number     = '4'
 text_file_extensions            = 'bash csv c cpp csharp css diff fortran gams gauss go graphql ini irpf90 java js json julia julia-repl kotlin less lua makefile markdown md mathematica matlab maxima mizar objectivec openscad perl php php-template plaintext txt python py python-repl r ruby rust sas scilab scss shell sh sql stan stata swift typescript ts vbnet wasm xml yaml html'
 notifications_enabled           = 'true'
 python3_interpreter             = '/usr/bin/python3'
+
+measure_coverage                = 'false'

--- a/docs/administration/configuring-yoda.md
+++ b/docs/administration/configuring-yoda.md
@@ -510,6 +510,7 @@ enable_irods_consistency_check  | Install iRODS consistency checker tool (ichk)
 irods_consistency_check_version | iRODS consistency checker (ichk) version
 enable_icat_database_checker    | Install iCAT database checker
 icat_database_checker_version   | iCAT database checker version
+yoda_rulesets_measure_coverage  | Enable code coverage measurements in the ruleset. This is meant for use on development or test environments. Default: false
 
 ### Multithreading
 

--- a/roles/yoda_rulesets/defaults/main.yml
+++ b/roles/yoda_rulesets/defaults/main.yml
@@ -252,3 +252,6 @@ yoda_rulesets_vault_copy_multithread_enabled: true
 # Copy to vault configuration
 vault_copy_backoff_time: 900           # How many seconds to wait before trying to copy a certain folder to vault again
 vault_copy_max_retries: 5              # How many times to retry copy to vault on particular folder before failing and sending notification
+
+# Coverage measurements for development environments
+yoda_rulesets_measure_coverage: false

--- a/roles/yoda_rulesets/templates/rules_uu.cfg.j2
+++ b/roles/yoda_rulesets/templates/rules_uu.cfg.j2
@@ -114,6 +114,6 @@ remote_anonymous_access        = '{{ irods_anonymous_account_permit_addresses | 
 user_max_connections_enabled   = '{{ ["false", "true"][irods_user_max_connections_enabled|int] }}'
 user_max_connections_number    = '{{ irods_user_max_connections_number }}'
 
-
+measure_coverage               = '{{ ["false", "true"][yoda_rulesets_measure_coverage|int] }}'
 text_file_extensions           = '{{ text_file_extensions | join (" ") }}'
 notifications_enabled          = '{{ ["false", "true"][send_notifications|int] }}'


### PR DESCRIPTION
Add parameter for enabling code coverage measurements in the ruleset this parameter is meant for use on development and test environments.