### PR TITLE
YDA-6372: refresh priv-groups registry 

### DIFF
--- a/roles/yoda_rulesets/tasks/yoda-ruleset.yml
+++ b/roles/yoda_rulesets/tasks/yoda-ruleset.yml
@@ -18,22 +18,13 @@
   check_mode: false
 
 
-- name: Configure group-manager privilege groups and update registry
+- name: Configure group-manager privilege groups in iCAT database
+  become_user: "{{ irods_service_account }}"
+  become: true
+  ansible.builtin.command: # noqa no-changed-when
+    cmd: '/etc/irods/yoda-ruleset/tools/group-manager-setup.sh'
   when: priv_groups.stdout.find('priv-admin') == -1
-  block:
-    - name: Create groups
-      become_user: "{{ irods_service_account }}"
-      become: true
-      ansible.builtin.command:
-        cmd: '/etc/irods/yoda-ruleset/tools/group-manager-setup.sh'
-      changed_when: true
 
-    - name: Refresh priv_groups list
-      become_user: "{{ irods_service_account }}"
-      become: true
-      ansible.builtin.command: 'iadmin lg'
-      register: priv_groups
-      changed_when: false
 
 - name: Find out which system collections are present
   become_user: "{{ irods_service_account }}"
@@ -352,7 +343,7 @@
   # noqa no-changed-when
   ansible.builtin.command:
     ichmod -rM own priv-admin /{{ irods_zone }}/yoda/file_formats
-  when: (not ansible_check_mode) and priv_groups.stdout.find('priv-admin') != -1 and file_formats_access.rc != 0
+  when: not ansible_check_mode and file_formats_access.rc != 0
 
 
 - name: Ensure that Yoda publication directory is present

--- a/roles/yoda_rulesets/tasks/yoda-ruleset.yml
+++ b/roles/yoda_rulesets/tasks/yoda-ruleset.yml
@@ -18,11 +18,20 @@
   check_mode: false
 
 
-- name: Configure group-manager privilege groups in iCAT database
-  become_user: "{{ irods_service_account }}"
-  become: true
-  ansible.builtin.command: # noqa no-changed-when
-    cmd: '/etc/irods/yoda-ruleset/tools/group-manager-setup.sh'
+- name: Configure group-manager groups and update registry
+  block:
+    - name: Create privilege groups
+      become_user: "{{ irods_service_account }}"
+      become: true
+      ansible.builtin.command:
+        cmd: '/etc/irods/yoda-ruleset/tools/group-manager-setup.sh'
+      
+    - name: Refresh priv_groups list
+      become_user: "{{ irods_service_account }}"
+      become: true
+      ansible.builtin.command: 'iadmin lg'
+      register: priv_groups
+      changed_when: false
   when: priv_groups.stdout.find('priv-admin') == -1
 
 

--- a/roles/yoda_rulesets/tasks/yoda-ruleset.yml
+++ b/roles/yoda_rulesets/tasks/yoda-ruleset.yml
@@ -19,20 +19,20 @@
 
 
 - name: Configure group-manager groups and update registry
+  when: priv_groups.stdout.find('priv-admin') == -1
   block:
-    - name: Create privilege groups
+    - name: Create priv-admin groups
       become_user: "{{ irods_service_account }}"
       become: true
       ansible.builtin.command:
         cmd: '/etc/irods/yoda-ruleset/tools/group-manager-setup.sh'
-      
+      changed_when: true 
+
     - name: Refresh priv_groups list
       become_user: "{{ irods_service_account }}"
       become: true
       ansible.builtin.command: 'iadmin lg'
       register: priv_groups
-      changed_when: false
-  when: priv_groups.stdout.find('priv-admin') == -1
 
 
 - name: Find out which system collections are present

--- a/roles/yoda_rulesets/tasks/yoda-ruleset.yml
+++ b/roles/yoda_rulesets/tasks/yoda-ruleset.yml
@@ -18,22 +18,22 @@
   check_mode: false
 
 
-- name: Configure group-manager groups and update registry
+- name: Configure group-manager privilege groups and update registry
   when: priv_groups.stdout.find('priv-admin') == -1
   block:
-    - name: Create priv-admin groups
+    - name: Create groups
       become_user: "{{ irods_service_account }}"
       become: true
       ansible.builtin.command:
         cmd: '/etc/irods/yoda-ruleset/tools/group-manager-setup.sh'
-      changed_when: true 
+      changed_when: true
 
     - name: Refresh priv_groups list
       become_user: "{{ irods_service_account }}"
       become: true
       ansible.builtin.command: 'iadmin lg'
       register: priv_groups
-
+      changed_when: false
 
 - name: Find out which system collections are present
   become_user: "{{ irods_service_account }}"


### PR DESCRIPTION
Root cause: the following task to grant priv-admin permission is skipped due to a logic hole.
```
- name: Ensure priv-admin group has ownership to make changes to preservable file formats lists
  become_user: "{{ irods_service_account }}"
  become: true
  # noqa no-changed-when
  ansible.builtin.command:
    ichmod -rM own priv-admin /{{ irods_zone }}/yoda/file_formats
  when: (not ansible_check_mode) and priv_groups.stdout.find('priv-admin') != -1 and file_formats_access.rc != 0
```

Because `priv_groups.stdout.find('priv-admin') != -1` priv_groups registry is stale, aka not updated after the priv-admin group is created.

Workflow: iadmin lg → No priv-admin found → priv_groups registered without priv-admin -> created priv-admin -> check no priv-admin in the stale priv_groups -> skipped permission assignment 

~~Solution: refresh priv-groups registry after priv-admin created~~

Solution: remove one of the condition to check priv-admin availability within the stale priv_groups 
