### PR TITLE
YDA-6256: fix EUS initialization error

### DIFF
--- a/docker/images/yoda_eus/yoda-external-user-service-vhost.conf
+++ b/docker/images/yoda_eus/yoda-external-user-service-vhost.conf
@@ -14,8 +14,8 @@
         Require all granted
     </Directory>
 
-    WSGIDaemonProcess yoda_eus user=yodadeployment group=yodadeployment threads=5 python-home=/var/www/extuser/yoda-external-user-service/venv
-    WSGIProcessGroup yoda_eus
+    WSGIDaemonProcess yoda_eus_noapi user=yodadeployment group=yodadeployment threads=5 python-home=/var/www/extuser/yoda-external-user-service/venv
+    WSGIProcessGroup yoda_eus_noapi
     WSGIScriptAlias / /var/www/extuser/yoda_eus_noapi.wsgi
     WSGIScriptReloading On
     WSGIPassAuthorization On
@@ -54,7 +54,7 @@ Listen 8443
     </Directory>
 
     WSGIDaemonProcess yoda_eus_api user=yodadeployment group=yodadeployment threads=5 python-home=/var/www/extuser/yoda-external-user-service/venv
-    WSGIProcessGroup yoda_eus
+    WSGIProcessGroup yoda_eus_api
     WSGIScriptAlias / /var/www/extuser/yoda_eus_api.wsgi
     WSGIScriptReloading On
     WSGIPassAuthorization On

--- a/roles/yoda_external_user_service/templates/yoda-external-user-service-vhost.conf.j2
+++ b/roles/yoda_external_user_service/templates/yoda-external-user-service-vhost.conf.j2
@@ -23,8 +23,8 @@ Listen {{ yoda_eus_port }}
         Require all granted
     </Directory>
 
-    WSGIDaemonProcess yoda_eus user={{ yoda_deployment_user }} group={{ yoda_deployment_user }} threads=5 python-home=/var/www/extuser/yoda-external-user-service/venv
-    WSGIProcessGroup yoda_eus
+    WSGIDaemonProcess yoda_eus_noapi user={{ yoda_deployment_user }} group={{ yoda_deployment_user }} threads=5 python-home=/var/www/extuser/yoda-external-user-service/venv
+    WSGIProcessGroup yoda_eus_noapi
     WSGIScriptAlias / /var/www/extuser/yoda_eus_noapi.wsgi
     WSGIScriptReloading On
     WSGIPassAuthorization On
@@ -65,7 +65,7 @@ Listen {{ eus_api_port }}
     </Directory>
 
     WSGIDaemonProcess yoda_eus_api user={{ yoda_deployment_user }} group={{ yoda_deployment_user }} threads=5 python-home=/var/www/extuser/yoda-external-user-service/venv
-    WSGIProcessGroup yoda_eus
+    WSGIProcessGroup yoda_eus_api
     WSGIScriptAlias / /var/www/extuser/yoda_eus_api.wsgi
     WSGIScriptReloading On
     WSGIPassAuthorization On


### PR DESCRIPTION
This PR fixes the initialization error observed in the EUS, caused by WSGI script conflict (new Flask-session version switched to msgspec, which caused initialization error as the WSGI daemon processes were under the same process group)