### PR TITLE
yda-6444: use PAM for davrods's authentication scheme temporarily

### DIFF
--- a/roles/yoda_davrods/defaults/main.yml
+++ b/roles/yoda_davrods/defaults/main.yml
@@ -9,6 +9,7 @@ yoda_davrods_anonymous_fqdn: public.data.yoda.test
 yoda_davrods_anonymous_port: 443
 
 yoda_davrods_logo_link: https://www.uu.nl
+yoda_davrods_authentication_scheme: PAM     # Yoda Davrods authentication method: "Native" or "PAM"
 
 yoda_portal_fqdn: portal.yoda.test          # Yoda Portal fully qualified domain name (FQDN)
 

--- a/roles/yoda_davrods/templates/davrods-vhost.conf.j2
+++ b/roles/yoda_davrods/templates/davrods-vhost.conf.j2
@@ -89,10 +89,13 @@ Listen {{ yoda_davrods_port }}
 
         # Authentication type to use when connecting to iRODS.
         #
-        # Supported authentication types are 'Native' and 'Pam'.
+        # Supported authentication types are 'Native' and 'PAM'.
         # ('Native' corresponds to what was formerly called 'Standard' auth in iRODS).
-        #
-        DavRodsAuthScheme      {{ irods_authentication_scheme }}
+        # ('PAM' is replaced by 'pam_password' after iRODS 4.3.1).
+
+        # TEMP: Legacy auth required for DavRods compat (Native/PAM only)
+        # TODO: Revert to {{ irods_authentication_scheme }} after scheme/DavRods update
+        DavRodsAuthScheme      {{ yoda_davrods_authentication_scheme }}
 
         # Anonymous mode switch.
         #


### PR DESCRIPTION
Logic of the error being triggered:
Davords uses the old naming of authentication, as "PAM". While the new irods uses the ‘pam_passwd' as the naming. So Davrods doesn't recognize the pam_passwd and triggered the error for apache restart. Thus Portal is not updated because apache (httpd) was not restarted successfully. 
