### PR TITLE
YDA-6487: fix CA cert setting

### DIFF
--- a/environments/development/allinone/group_vars/allinone.yml
+++ b/environments/development/allinone/group_vars/allinone.yml
@@ -87,6 +87,7 @@ irods_database_fqdn: combined.yoda.test    # iRODS database fully qualified doma
 irods_resource_fqdn: combined.yoda.test    # iRODS resource fully qualified domain name (FQDN)
 irods_ssl_verify_server: none              # Verify TLS certificate, use 'cert' for acceptance and production
 irods_enable_gocommands: false
+irods_ca_certificate_file: "/etc/irods/{{ openssl_crt_signed_and_chain }}"
 irods_resources:
   - name: dev001_1
     host: "{{ irods_icat_fqdn }}"

--- a/environments/development/full/group_vars/full.yml
+++ b/environments/development/full/group_vars/full.yml
@@ -85,6 +85,7 @@ irods_icat_fqdn: icat.yoda.test            # iRODS iCAT fully qualified domain n
 irods_database_fqdn: database.yoda.test    # iRODS database fully qualified domain name (FQDN)
 irods_resource_fqdn: resource.yoda.test    # iRODS resource fully qualified domain name (FQDN)
 irods_ssl_verify_server: none              # Verify TLS certificate, use 'cert' for acceptance and production
+irods_ca_certificate_file: "/etc/irods/{{ openssl_crt_signed_and_chain }}"
 irods_enable_gocommands: false
 irods_anonymous_account_permit_addresses: ['192.168.56.10']
 irods_resources:

--- a/environments/development/single_fqdn/group_vars/single_fqdn.yml
+++ b/environments/development/single_fqdn/group_vars/single_fqdn.yml
@@ -90,6 +90,7 @@ irods_icat_fqdn: combined.yoda.test        # iRODS iCAT fully qualified domain n
 irods_database_fqdn: combined.yoda.test    # iRODS database fully qualified domain name (FQDN)
 irods_resource_fqdn: combined.yoda.test    # iRODS resource fully qualified domain name (FQDN)
 irods_ssl_verify_server: none              # Verify TLS certificate, use 'cert' for acceptance and production
+irods_ca_certificate_file: "/etc/irods/{{ openssl_crt_signed_and_chain }}"
 irods_enable_gocommands: false
 irods_resources:
   - name: dev001_1

--- a/environments/development/surf/group_vars/surf.yml
+++ b/environments/development/surf/group_vars/surf.yml
@@ -85,6 +85,7 @@ irods_icat_fqdn: portal.surfyoda.test        # iRODS iCAT fully qualified domain
 irods_database_fqdn: portal.surfyoda.test    # iRODS database fully qualified domain name (FQDN)
 # irods_resource_fqdn: resource.surfyoda.test # iRODS resource fully qualified domain name (FQDN)
 irods_ssl_verify_server: none                # Verify TLS certificate, use 'cert' for acceptance and production
+irods_ca_certificate_file: "/etc/irods/{{ openssl_crt_signed_and_chain }}"
 irods_enable_gocommands: false
 irods_anonymous_account_permit_addresses: ['192.168.56.21']
 irods_resources:

--- a/roles/irods_icat/defaults/main.yml
+++ b/roles/irods_icat/defaults/main.yml
@@ -22,6 +22,7 @@ irods_vault_directory: /var/lib/irods/Vault
 irods_control_plane_port: 1248
 irods_schema_uri: file:///var/lib/irods/configuration_schemas
 irods_ssl_verify_server: cert
+irods_ca_certificate_file: "{{ openssl_ca_certs_bundle }}"
 
 irods_icat_caching_settings:
   advanced_settings/dns_cache/eviction_age_in_seconds: 3600

--- a/roles/irods_icat/tasks/main.yml
+++ b/roles/irods_icat/tasks/main.yml
@@ -372,7 +372,7 @@
     - key: 'irods_ssl_certificate_chain_file'
       value: '/etc/irods/{{ openssl_crt_signed_and_chain }}'
     - key: 'irods_ssl_ca_certificate_file'
-      value: '/etc/irods/{{ openssl_crt_signed_and_chain }}'
+      value: '{{ irods_ca_certificate_file }}'
     - key: 'irods_ssl_certificate_key_file'
       value: '/etc/irods/{{ openssl_key_signed }}'
     - key: 'irods_ssl_dh_params_file'

--- a/roles/irods_icat/vars/Debian.yml
+++ b/roles/irods_icat/vars/Debian.yml
@@ -3,6 +3,7 @@
 
 openssl_private_dir: '/etc/ssl/private/'
 openssl_certs_dir: '/etc/ssl/certs'
+openssl_ca_certs_bundle: /etc/ssl/certs/ca-certificates.crt
 
 pam_radius_package: libpam-radius-auth
 

--- a/roles/irods_icat/vars/RedHat.yml
+++ b/roles/irods_icat/vars/RedHat.yml
@@ -3,6 +3,7 @@
 
 openssl_private_dir: '/etc/pki/tls/private'
 openssl_certs_dir: '/etc/pki/tls/certs'
+openssl_ca_certs_bundle: /etc/ssl/certs/ca-bundle.crt
 
 pam_radius_package: pam_radius
 

--- a/roles/irods_resource/defaults/main.yml
+++ b/roles/irods_resource/defaults/main.yml
@@ -16,6 +16,7 @@ irods_vault_directory: /var/lib/irods/Vault
 irods_control_plane_port: 1248
 irods_schema_uri: file:///var/lib/irods/configuration_schemas
 irods_ssl_verify_server: cert
+irods_ca_certificate_file: "{{ openssl_ca_certs_bundle }}"
 
 irods_resource_caching_settings:
   advanced_settings/dns_cache/eviction_age_in_seconds: 3600

--- a/roles/irods_resource/tasks/main.yml
+++ b/roles/irods_resource/tasks/main.yml
@@ -254,6 +254,8 @@
   with_items:
     - key: 'irods_ssl_certificate_chain_file'
       value: '/etc/irods/{{ openssl_crt_signed_and_chain }}'
+    - key: 'irods_ssl_ca_certificate_file'
+      value: '{{ irods_ca_certificate_file }}'
     - key: 'irods_ssl_certificate_key_file'
       value: '/etc/irods/{{ openssl_key_signed }}'
     - key: 'irods_ssl_dh_params_file'

--- a/roles/irods_resource/vars/Debian.yml
+++ b/roles/irods_resource/vars/Debian.yml
@@ -3,6 +3,7 @@
 
 openssl_private_dir: '/etc/ssl/private/'
 openssl_certs_dir: '/etc/ssl/certs'
+openssl_ca_certs_bundle: /etc/ssl/certs/ca-certificates.crt
 
 irods_runtime_package_new: irods-runtime=4.3.4-0~noble
 irods_server_package_new: irods-server=4.3.4-0~noble

--- a/roles/irods_resource/vars/RedHat.yml
+++ b/roles/irods_resource/vars/RedHat.yml
@@ -3,6 +3,7 @@
 
 openssl_private_dir: '/etc/pki/tls/private'
 openssl_certs_dir: '/etc/pki/tls/certs'
+openssl_ca_certs_bundle: /etc/ssl/certs/ca-bundle.crt
 
 irods_runtime_package_new: irods-runtime-4.3.4-0.el9
 irods_server_package_new: irods-server-4.3.4-0.el9

--- a/roles/yoda_portal/defaults/main.yml
+++ b/roles/yoda_portal/defaults/main.yml
@@ -47,6 +47,8 @@ irods_authentication_scheme: pam_password  # iRODS authentication method: "nativ
 irods_zone: tempZone                       # The name of the iRODS Zone
 irods_icat_fqdn: icat.yoda.test            # iRODS iCAT fully qualified domain name (FQDN)
 irods_icat_port: 1247
+irods_ssl_verify_server: cert
+irods_ca_certificate_file: "{{ openssl_ca_certs_bundle }}"
 
 # OpenSSL configuration.
 openssl_key_signed: localhost.key

--- a/roles/yoda_portal/templates/flask.cfg.j2
+++ b/roles/yoda_portal/templates/flask.cfg.j2
@@ -34,13 +34,13 @@ IRODS_ICAT_HOSTNAME = '{{ irods_icat_fqdn }}'
 IRODS_ICAT_PORT     = '{{ irods_icat_port }}'
 IRODS_DEFAULT_ZONE  = '{{ irods_zone }}'
 IRODS_DEFAULT_RESC  = '{{ irods_default_resc }}'
-IRODS_SSL_CA_FILE   = '{{ openssl_certs_dir ~ "/" ~ openssl_crt_signed_and_chain }}'
+IRODS_SSL_CA_FILE   = '{{ irods_ca_certificate_file }}'
 IRODS_AUTH_SCHEME   = '{{ irods_authentication_scheme }}'
 IRODS_CLIENT_OPTIONS_FOR_SSL = {
     "irods_client_server_policy": "CS_NEG_REQUIRE",
     "irods_client_server_negotiation": "request_server_negotiation",
     "irods_ssl_ca_certificate_file": IRODS_SSL_CA_FILE,
-    "irods_ssl_verify_server": "cert",
+    "irods_ssl_verify_server": "{{ irods_ssl_verify_server }}",
     "irods_encryption_key_size": 16,
     "irods_encryption_salt_size": 8,
     "irods_encryption_num_hash_rounds": 16,

--- a/roles/yoda_portal/vars/Debian.yml
+++ b/roles/yoda_portal/vars/Debian.yml
@@ -3,6 +3,7 @@
 
 openssl_private_dir: '/etc/ssl/private/'
 openssl_certs_dir: '/etc/ssl/certs'
+openssl_ca_certs_bundle: /etc/ssl/certs/ca-certificates.crt
 
 yoda_portal_python3_path: /usr/bin/python3
 yoda_portal_python3_include_path: /usr/include/python3.12

--- a/roles/yoda_portal/vars/RedHat.yml
+++ b/roles/yoda_portal/vars/RedHat.yml
@@ -3,6 +3,7 @@
 
 openssl_private_dir: '/etc/pki/tls/private'
 openssl_certs_dir: '/etc/pki/tls/certs'
+openssl_ca_certs_bundle: /etc/ssl/certs/ca-bundle.crt
 
 yoda_portal_python3_path: /usr/bin/python3.12
 yoda_portal_python3_include_path: /usr/include/python3.12


### PR DESCRIPTION
Ensure that iRODS and the portal use the system CA certificate bundle by default. However, on the development environments it needs to use the certificate file itself, since these environments use self-signed certificates.