### PR TITLE
YDA-6506: Davrods adaptations for Ubuntu 24.04 LTS

### DIFF
--- a/.github/workflows/build-push-image-davrods.yml
+++ b/.github/workflows/build-push-image-davrods.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - '.github/workflows/build-push-image-davrods.yml'
       - 'docker/images/davrods/**'
+      - 'roles/yoda_davrods/files/initialize-davrods-lockdb.py'
 
 jobs:
   push-image:
@@ -36,6 +37,11 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Stage files for Docker image
+      run: |
+        cd yoda/docker/images/davrods
+        ./stage-uploads.sh
 
     - name: Build and push Docker image
       uses: docker/build-push-action@v6

--- a/docker/images/davrods/Dockerfile
+++ b/docker/images/davrods/Dockerfile
@@ -58,7 +58,7 @@ RUN apt-get -y install libboost-all-dev libjansson4 && \
     dpkg -i "/download/$DAVRODS_APT_PACKAGE"
 
 # Copy DavRODS VHost and iRODS configuration files
-COPY davrods-vhost.conf /etc/apache2/stes-available/davrods-vhost.conf
+COPY davrods-vhost.conf /etc/apache2/sites-available/davrods-vhost.conf
 COPY davrods-anonymous-vhost.conf /etc/apache2/sites-available/davrods-anonymous-vhost.conf
 RUN ln -s /etc/apache2/sites-available/davrods-vhost.conf /etc/apache2/sites-enabled/davrods-vhost.conf
 RUN ln -s /etc/apache2/sites-available/davrods-anonymous-vhost.conf /etc/apache2/sites-enabled/davrods-anonymous-vhost.conf
@@ -69,9 +69,12 @@ COPY header.html /etc/apache2/irods/header.html
 COPY head.html /etc/apache2/irods/head.html
 COPY footer.html /etc/apache2/irods/footer.html
 
+# Copy DavRODS DB initialization script
+COPY stage/initialize-davrods-lockdb.py /usr/local/bin/initialize-davrods-lockdb.py
+
 # Initialize
 VOLUME [ "/sys/fs/cgroup" ]
 COPY davrods_init.sh /var/lib/irods/scripts/davrods_init.sh
-RUN chmod 0755 /var/lib/irods/scripts/davrods_init.sh
+RUN chmod 0755 /var/lib/irods/scripts/davrods_init.sh /usr/local/bin/initialize-davrods-lockdb.py
 ENV TAG=${TAG}
 CMD exec /var/lib/irods/scripts/davrods_init.sh $TAG

--- a/docker/images/davrods/davrods-anonymous-vhost.conf
+++ b/docker/images/davrods/davrods-anonymous-vhost.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-# davrods-vhost.conf
+# davrods-anonymous-vhost.conf
 #
 # davrods is a mod_dav WebDAV provider. Configuration directives for davrods
 # should be placed in a <Location> block.

--- a/docker/images/davrods/davrods_init.sh
+++ b/docker/images/davrods/davrods_init.sh
@@ -47,6 +47,16 @@ install -m 0644 docker.key /etc/ssl/private/localhost.key
 install -m 0644 dhparam.pem /etc/ssl/private/dhparams.pem
 progress_update "Certificate data extracted"
 
+# Initialize lock database
+if [[ -f "/var/lib/irods/lockdb_locallock" ]]
+then progress_update "Lock database has already been initialized"
+else before_update "Initializing lock database"
+     /usr/local/bin/initialize-davrods-lockdb.py /var/lib/davrods
+     chown -R www-data:www-data /var/lib/davrods
+     chmod 0775 /var/lib/davrods
+     progress_update "Lock database initialized"
+fi
+
 # Start Apache
 touch /container_initialized
 before_update "Initialization complete. Starting Apache"

--- a/docs/development/docker-setup.md
+++ b/docs/development/docker-setup.md
@@ -184,6 +184,7 @@ cd docker/images/yoda_portal
 
 ```bash
 cd docker/images/davrods
+./stage-uploads.sh
 ./build.sh
 ```
 

--- a/roles/apache/templates/usr.sbin.apache2.j2
+++ b/roles/apache/templates/usr.sbin.apache2.j2
@@ -51,6 +51,7 @@
   owner /opt/irods-externals/** mr,
   owner /run/apache2/apache2.pid rw,
   owner /run/apache2/apache2.pid.* rw,
+  owner /var/lib/davrods rw,
   owner /var/lib/davrods/__db.lockdb_locallock rw,
   owner /var/lib/davrods/lockdb_locallock rw,
   owner /var/www/extuser/ r,

--- a/roles/yoda_davrods/defaults/main.yml
+++ b/roles/yoda_davrods/defaults/main.yml
@@ -10,6 +10,7 @@ yoda_davrods_anonymous_port: 443
 
 yoda_davrods_logo_link: https://www.uu.nl
 yoda_davrods_authentication_scheme: PAM     # Yoda Davrods authentication method: "Native" or "PAM"
+yoda_davrods_lockdir: /var/lib/davrods
 
 yoda_portal_fqdn: portal.yoda.test          # Yoda Portal fully qualified domain name (FQDN)
 

--- a/roles/yoda_davrods/files/initialize-davrods-lockdb.py
+++ b/roles/yoda_davrods/files/initialize-davrods-lockdb.py
@@ -1,0 +1,31 @@
+#!/usr/bin/python3
+
+"""Initializes a Davrods lock database on an Ubuntu system."""
+
+import argparse
+import dbm.ndbm
+import os
+import sys
+
+
+def get_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('directory', type=str,
+                        help='DavRODS lock directory')
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = get_args()
+    if os.path.isdir(args.directory):
+        basename = os.path.join(args.directory, "lockdb_locallock")
+        dbname = os.path.join(args.directory, "lockdb_locallock.db")
+    else:
+        sys.exit("Error: directory does not exist")
+
+    if os.path.exists(dbname):
+        print("Not doing anything, since DB already exists.")
+    else:
+        with dbm.ndbm.open(basename, "n") as db:
+            pass
+        os.rename(dbname, basename)

--- a/roles/yoda_davrods/tasks/main.yml
+++ b/roles/yoda_davrods/tasks/main.yml
@@ -22,6 +22,11 @@
   when: ansible_os_family == 'Debian'
 
 
+- name: Set up lock database (Ubuntu)
+  ansible.builtin.import_tasks: setup-lockdatabase-ubuntu.yml
+  when: ansible_os_family == 'Debian'
+
+
 - name: Setup SELinux for DavRODS (EL)
   ansible.builtin.import_tasks: setup-selinux.yml
   when: ansible_os_family == 'RedHat' and ansible_selinux.status == "enabled"

--- a/roles/yoda_davrods/tasks/setup-lockdatabase-ubuntu.yml
+++ b/roles/yoda_davrods/tasks/setup-lockdatabase-ubuntu.yml
@@ -1,0 +1,35 @@
+---
+# copyright Utrecht University
+
+- name: Set ACLs Davrods lock database directory
+  ansible.builtin.file:
+    path: '{{ yoda_davrods_lockdir }}'
+    state: directory
+    owner: '{{ yoda_davrods_user }}'
+    group: '{{ yoda_davrods_group }}'
+    mode: '0775'
+  when: not ansible_check_mode
+
+
+- name: Upload Davrods lock database initialization script
+  ansible.builtin.copy:
+    src: initialize-davrods-lockdb.py
+    dest: /usr/local/bin/initialize-davrods-lockdb.py
+    owner: root
+    group: root
+    mode: '0755'
+
+
+- name: Initialize Davrods lock database if needed
+  ansible.builtin.command:
+    cmd: '/usr/local/bin/initialize-davrods-lockdb.py  {{ yoda_davrods_lockdir }}'
+    creates: '{{ yoda_davrods_lockdir }}/lockdb_locallock'
+
+
+- name: Set permissions Davrods lock database
+  ansible.builtin.file:
+    path: '{{ yoda_davrods_lockdir }}/lockdb_locallock'
+    owner: '{{ yoda_davrods_user }}'
+    group: '{{ yoda_davrods_group }}'
+    mode: '0660'
+  when: not ansible_check_mode

--- a/roles/yoda_davrods/vars/Debian.yml
+++ b/roles/yoda_davrods/vars/Debian.yml
@@ -20,3 +20,4 @@ yoda_davrods_anon_config_file: 006-davrods-anonymous-vhost.conf
 yoda_davrods_apache_log_dir: /var/log/apache2
 yoda_davrods_config_dir: /etc/apache2/irods
 yoda_davrods_user: www-data
+yoda_davrods_group: www-data

--- a/roles/yoda_davrods/vars/RedHat.yml
+++ b/roles/yoda_davrods/vars/RedHat.yml
@@ -18,3 +18,4 @@ yoda_davrods_apache_log_dir: /var/log/httpd
 yoda_davrods_irods_dir: /etc/httpd/irods
 yoda_davrods_config_dir: /etc/httpd/irods
 yoda_davrods_user: apache
+yoda_davrods_group: apache


### PR DESCRIPTION
Ensure that DavRODS works correctly on Ubuntu 24.04 LTS when deployed via either Ansible or Docker:
- Adjust permissions Davrods lock directory
- Add script to initialize lock database correctly
- Adjust AppArmor configuration Apache for Davrods
- Some other fixes/tweaks in the Docker setup for Davrods