### PR TITLE
YDA-6486: fix issue of creating the same resource in consumer as in provider

### DIFF
--- a/roles/irods_resource/templates/setup_irods_consumer.json.j2
+++ b/roles/irods_resource/templates/setup_irods_consumer.json.j2
@@ -1,6 +1,6 @@
 {
   "admin_password": "{{ irods_password }}",
-  "default_resource_directory": "",
+  "default_resource_directory": null,
   "default_resource_name": "{{ irods_default_resc }}",
   "host_system_information": {
     "service_account_group_name": "{{ irods_service_account }}",


### PR DESCRIPTION
This is a fix for the issue following issue which happens while deploying Yoda 2.0.0-rc.1 in a full deployment environment and the playbook initially fails when deploying iRODS to the consumer.