### PR TITLE
fix: datacite-mock should match the icat host

### DIFF
--- a/vagrant/environments/almalinux9-full/Vagrantfile
+++ b/vagrant/environments/almalinux9-full/Vagrantfile
@@ -62,7 +62,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       machine.vm.provision "shell",
         inline: "sudo echo \"192.168.56.14 api.eus.yoda.test\" | sudo tee -a /etc/hosts"
       machine.vm.provision "shell",
-        inline: "sudo echo \"192.168.56.10 datacite-mock.yoda.test\" | sudo tee -a /etc/hosts"
+        inline: "sudo echo \"192.168.56.12 datacite-mock.yoda.test\" | sudo tee -a /etc/hosts"
       machine.vm.provision "shell",
         inline: "sudo echo \"192.168.56.10 sram-mock.yoda.test\" | sudo tee -a /etc/hosts"
     end

--- a/vagrant/environments/ubuntu2404-full/Vagrantfile
+++ b/vagrant/environments/ubuntu2404-full/Vagrantfile
@@ -58,7 +58,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       machine.vm.provision "shell",
         inline: "sudo echo \"192.168.56.14 api.eus.yoda.test\" | sudo tee -a /etc/hosts"
       machine.vm.provision "shell",
-        inline: "sudo echo \"192.168.56.10 datacite-mock.yoda.test\" | sudo tee -a /etc/hosts"
+        inline: "sudo echo \"192.168.56.12 datacite-mock.yoda.test\" | sudo tee -a /etc/hosts"
       machine.vm.provision "shell",
         inline: "sudo echo \"192.168.56.10 sram-mock.yoda.test\" | sudo tee -a /etc/hosts"
     end


### PR DESCRIPTION
Fixes the datacite-mock host in Vagrantfile of full deployments to be the same as the icat host one.