### PR TITLE
YDA-6530 fix microservices deployment fail

### DIFF
--- a/roles/common/tasks/basics-redhat.yml
+++ b/roles/common/tasks/basics-redhat.yml
@@ -35,3 +35,8 @@
       - jq
       - curl
     state: present
+
+
+- name: Gather package facts
+  ansible.builtin.package_facts:
+    manager: rpm


### PR DESCRIPTION
Deploying microservices packages using the Ansible playbook on an EL9 full development setup failed due to the playbook not collecting package facts before running the microservices role. This change ensures that package facts are always collected on EL systems when running the playbook.