### PR TITLE
YDA-6352: add DNS issue workaround on dev envs

### DIFF
--- a/environments/development/allinone/group_vars/allinone.yml
+++ b/environments/development/allinone/group_vars/allinone.yml
@@ -6,6 +6,9 @@ ansible_user: vagrant                             # Administrative user on insta
 ansible_ssh_private_key_file: vagrant/ssh/vagrant # Path to private key file of administrative user
 ansible_python_interpreter: /usr/bin/python3      # Path to Python interpreter on the target host
 
+# This is a workaround for an issue with resource creation on EL 9 systems (see YDA-6324)
+common_custom_dns_enable: true
+
 # Yoda configuration
 instance: allinone                                 # Name of Yoda instance, as defined in hosts file
 yoda_version: development                          # Git branch, for example: development or release-1.8

--- a/environments/development/full/group_vars/full.yml
+++ b/environments/development/full/group_vars/full.yml
@@ -6,6 +6,9 @@ ansible_user: vagrant                             # Administrative user on insta
 ansible_ssh_private_key_file: vagrant/ssh/vagrant # Path to private key file of administrative user
 ansible_python_interpreter: /usr/bin/python3      # Path to Python interpreter on the target host
 
+# This is a workaround for an issue with resource creation on EL 9 systems (see YDA-6324)
+common_custom_dns_enable: true
+
 # Yoda configuration
 instance: full                                     # Name of Yoda instance, as defined in hosts file
 yoda_version: development                          # Git branch, for example: development or release-1.5

--- a/environments/development/single_fqdn/group_vars/single_fqdn.yml
+++ b/environments/development/single_fqdn/group_vars/single_fqdn.yml
@@ -6,6 +6,9 @@ ansible_user: vagrant                             # Administrative user on insta
 ansible_ssh_private_key_file: vagrant/ssh/vagrant # Path to private key file of administrative user
 ansible_python_interpreter: /usr/bin/python3      # Path to Python interpreter on the target host
 
+# This is a workaround for an issue with resource creation on EL 9 systems (see YDA-6324)
+common_custom_dns_enable: true
+
 pgsql_version: 15
 postgresql_perform_db_upgrade: true
 

--- a/environments/development/surf/group_vars/surf.yml
+++ b/environments/development/surf/group_vars/surf.yml
@@ -6,6 +6,9 @@ ansible_user: vagrant                             # Administrative user on insta
 ansible_ssh_private_key_file: vagrant/ssh/vagrant # Path to private key file of administrative user
 ansible_python_interpreter: /usr/bin/python3      # Path to Python interpreter on the target host
 
+# This is a workaround for an issue with resource creation on EL 9 systems (see YDA-6324)
+common_custom_dns_enable: true
+
 # Yoda configuration
 instance: surf                                     # Name of Yoda instance, as defined in hosts file
 yoda_version: development                          # Git branch, for example: development or release-1.5


### PR DESCRIPTION
On the development environments, change DNS settings in order to work around an issue with resource creation on EL 9 systems (see YDA-6324).