### PR TITLE
YDA-6597: Restart portal after changes

### DIFF
--- a/roles/yoda_portal/handlers/main.yml
+++ b/roles/yoda_portal/handlers/main.yml
@@ -5,3 +5,8 @@
   ansible.builtin.service:
     name: "{{ apache_service_name }}"
     state: restarted
+
+
+- name: Restart portal application
+  ansible.builtin.command: # noqa no-changed-when
+    cmd: /bin/touch /var/www/yoda/yoda.wsgi /var/www/yoda/yoda_debug.wsgi

--- a/roles/yoda_portal/tasks/main.yml
+++ b/roles/yoda_portal/tasks/main.yml
@@ -28,6 +28,9 @@
     version: "{{ yoda_portal_version }}"
     force: "yes"
   register: portalchanges
+  notify:
+    - Restart Apache webserver
+    - Restart portal application
 
 
 - name: Ensure Yoda portal virtualenv exists
@@ -56,7 +59,9 @@
     virtualenv_python: python3.12
   environment:
     C_INCLUDE_PATH: "{{ yoda_portal_python3_include_path }}"
-  notify: Restart Apache webserver
+  notify:
+    - Restart Apache webserver
+    - Restart portal application
 
 
 - name: Install mod-wsgi
@@ -110,7 +115,9 @@
     owner: "{{ yoda_deployment_user }}"
     group: "{{ yoda_deployment_user }}"
   when: not ansible_check_mode
-  notify: Restart Apache webserver
+  notify:
+    - Restart Apache webserver
+    - Restart portal application
 
 
 - name: Copy Yoda Portal virtual host config for Apache


### PR DESCRIPTION
Explicitly restart the portal application after code or configuration changes. This ensures that the new config is loaded and that any changes (e.g. changes in JS dependencies) are activated. Just restarting the web server is not always sufficient.