### PR TITLE
YDA-6611: fix irods_database dependency

### DIFF
--- a/roles/irods_icat/meta/main.yml
+++ b/roles/irods_icat/meta/main.yml
@@ -15,7 +15,6 @@ galaxy_info:
 
 dependencies:
   - role: irods_remove_old_version
-  - role: irods_database
   - role: irods_icommands
   - role: python_irodsclient
   - role: sqlcipher


### PR DESCRIPTION
Remove irods_database dependency in irods_icat
role. This dependency assumed the iCAT database
and provider are on the same server, which is not
necessarily the case. Rely on order in playbook for
dependency of provider on iCAT database instead.