### PR TITLE
YDA-6546: Redact Apache web version

### DIFF
--- a/roles/apache/files/security.conf.noble
+++ b/roles/apache/files/security.conf.noble
@@ -1,0 +1,57 @@
+# Changing the following options will not really affect the security of the
+# server, but might make attacks slightly more difficult in some cases.
+
+#
+# ServerTokens
+# This directive configures what you return as the Server HTTP response
+# Header. The default is 'Full' which sends information about the OS-Type
+# and compiled in modules.
+# Set to one of:  Full | OS | Minimal | Minor | Major | Prod
+# where Full conveys the most information, and Prod the least.
+#ServerTokens Minimal
+ServerTokens Prod
+
+#
+# Optionally add a line containing the server version and virtual host
+# name to server-generated pages (internal error documents, FTP directory
+# listings, mod_status and mod_info output etc., but not CGI generated
+# documents or custom error documents).
+# Set to "EMail" to also include a mailto: link to the ServerAdmin.
+# Set to one of:  On | Off | EMail
+ServerSignature Off
+#ServerSignature On
+
+#
+# Allow TRACE method
+#
+# Set to "extended" to also reflect the request body (only for testing and
+# diagnostic purposes).
+#
+# Set to one of:  On | Off | extended
+TraceEnable Off
+#TraceEnable On
+
+#
+# Forbid access to version control directories
+#
+# If you use version control systems in your document root, you should
+# probably deny access to their directories.
+#
+# Examples:
+#
+#RedirectMatch 404 /\.git
+#RedirectMatch 404 /\.svn
+
+#
+# Setting this header will prevent MSIE from interpreting files as something
+# else than declared by the content type in the HTTP headers.
+# Requires mod_headers to be enabled.
+#
+#Header set X-Content-Type-Options: "nosniff"
+
+#
+# Setting this header will prevent other sites from embedding pages from this
+# site as frames. This defends against clickjacking attacks.
+# Requires mod_headers to be enabled.
+#
+#Header set Content-Security-Policy "frame-ancestors 'self';"

--- a/roles/apache/tasks/main-tasks.yml
+++ b/roles/apache/tasks/main-tasks.yml
@@ -66,6 +66,17 @@
   when: ansible_os_family == 'Debian'
 
 
+- name: Copy Apache security configuration file (Ubuntu)
+  ansible.builtin.copy:
+    src: security.conf.noble
+    dest: /etc/apache2/conf-available/security.conf
+    owner: root
+    group: root
+    mode: '0644'
+  notify: Restart Apache webserver
+  when: ansible_os_family == 'Debian'
+
+
 - name: Copy bad bots blocklist
   ansible.builtin.template:
     src: bad_bots.conf


### PR DESCRIPTION
Do not show Apache version in web server error messages, as a matter of standard security hardening.