### PR TITLE
Ensure irods logs readable by service account (set umask)

### DIFF
--- a/roles/irods_log/templates/rsyslogd-irods.conf.j2
+++ b/roles/irods_log/templates/rsyslogd-irods.conf.j2
@@ -1,5 +1,6 @@
 # {{ ansible_managed }}
 
+$umask 0000
 $WorkDirectory {{ irods_log_directory }}
 $FileOwner {{ irods_service_account }}
 $FileGroup {{ irods_service_account }}


### PR DESCRIPTION
This PR adjusts the log-handling configuration to ensure iRODS-related logs written through rsyslog are readable by the irods service account.

Previously, log files created by rsyslog (via the iRODS log transformer) inherited a restrictive umask, which prevented the irods user from reading them.

To resolve this, the configuration was updated to apply a neutral umask at startup, allowing $FileCreateMode and $DirCreateMode to take full effect and generate logs with consistent, readable permissions. 