### PR TITLE
yoda_report role: fix cronjobs for compatibility

### DIFF
--- a/roles/yoda_report/tasks/main.yml
+++ b/roles/yoda_report/tasks/main.yml
@@ -90,9 +90,7 @@
     name: "yoda-report-gather-group-statistics"
     minute: 0
     hour: 1
-    job: >
-      source /var/yoda-financial-data/yoda_report_venv/bin/activate &&
-      python /var/yoda-financial-data/gather-group-statistics.py
+    job: /var/yoda-financial-data/yoda_report_venv/bin/python /var/yoda-financial-data/gather-group-statistics.py
     user: "{{ irods_service_account }}"
     state: "{{ 'present' if enable_yoda_report else 'absent' }}"
   when: inventory_hostname in groups['icats']
@@ -117,9 +115,7 @@
     name: "yoda-report-gather-capacity-statistics"
     minute: 0
     hour: 1
-    job: >
-      source /var/yoda-financial-data/yoda_report_venv/bin/activate &&
-      python /var/yoda-financial-data/gather-capacity-stats.py
+    job: /var/yoda-financial-data/yoda_report_venv/bin/python /var/yoda-financial-data/gather-capacity-stats.py
     user: "{{ irods_service_account }}"
     state: "{{ 'present' if enable_yoda_report else 'absent' }}"
 


### PR DESCRIPTION
Ensure we use dash-compatible syntax in reporting cronjobs so that the jobs also work on Ubuntu 24.04 LTS