### PR TITLE
YDA-6663: add download worker pool to landing page

### DIFF
--- a/roles/yoda_landingpages/files/js/download.js
+++ b/roles/yoda_landingpages/files/js/download.js
@@ -48,20 +48,35 @@ document.body.addEventListener('click', async function (event) {
 })
 
 async function downloadEntriesAsZip (entries) {
-  const zipEntries = await Promise.all(
-    entries.map(async ({ url, name }) => {
-      if (!url) return { name }
+  const MAX_PARALLEL = 2
+
+  const results = new Array(entries.length)
+  let cursor = 0
+
+  async function worker () {
+    while (cursor < entries.length) {
+      const i = cursor++
+      const { url, name } = entries[i]
+
+      if (!url) { 
+        results[i] = { name }
+        continue
+      }
 
       const response = await fetch(url)
       if (!response.ok) {
         throw new Error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`)
       }
+      const blob = await response.blob()   // blocks until finished, this prevent more than MAX_PARALLEL threads running
 
-      return { name, lastModified: Date.now(), input: response }
-    })
-  )
+      results[i] = { name, lastModified: Date.now(), input: blob }
+    }
+  }
 
-  const zipBlob = await downloadZip(zipEntries).blob()
+  const workers = Array.from({ length: Math.min(MAX_PARALLEL, entries.length) }, worker)
+  await Promise.all(workers)
+
+  const zipBlob = await downloadZip(results).blob()
   const downloadLink = document.createElement('a')
   downloadLink.href = URL.createObjectURL(zipBlob)
   downloadLink.download = 'download.zip'


### PR DESCRIPTION
This adds a worker pool for downloading as ZIP from the client side (Java script). 

Issue identified:
1. With more than 6 users (browers) downloading as ZIP in parrallel, normal user's irods requests would be significantly slowed. And with 8 users downloading, the irods requests from normal user is completely frozen. (Env: ubuntu 24, local VM, the max irods connections is about 30, as derived from "ips" icmd) 

This script can:
1. Improve the max number of users simultaneously downloading data as ZIP from landing pages, by a factor about 1.5. The impact to downloading time is expected to be small, as the time is limited by the bandwidth mostly. Without limitation, each browser allows max 6 requests firing in parallel when downloading as ZIP, which creates 6 connections to IRODS through webdav. After applying the updated script, the number of connections to irods is down to 2-4. And for the issue identified with 6-8 users, the portal is still responsive as normal in the local VM env. Not sure about the scenario with more number (>8) of users. 

This script can NOT:
1. Limit the requests from web scrapers. 