### PR TITLE
YDA-6712: fix iRODS and Zabbix packages locks

### DIFF
--- a/roles/irods_icat/tasks/main.yml
+++ b/roles/irods_icat/tasks/main.yml
@@ -30,7 +30,7 @@
   when: not ansible_check_mode
 
 
-- name: Ensure iRODS iCAT server and plugins are pinned
+- name: Ensure iRODS iCAT server and plugins are pinned (Ubuntu)
   ansible.builtin.template:
     src: 'irods_icat.pref.j2'
     dest: '/etc/apt/preferences.d/irods_icat.pref'
@@ -38,6 +38,17 @@
     owner: 'root'
     group: 'root'
   when: ansible_os_family == 'Debian'
+
+
+- name: Ensure iRODS packages have version locks (EL)
+  community.general.dnf_versionlock:
+    name:
+      - "{{ irods_server_package_new }}"
+      - "{{ irods_pgp_package_new }}"
+      - "{{ irods_prep_package_new }}"
+      # irods-runtime package is locked by irods_runtime role instead
+    state: present
+  when: ansible_os_family == 'RedHat'
 
 
 - name: Ensure iRODS indexing plugins are present
@@ -49,7 +60,7 @@
   when: not ansible_check_mode and enable_open_search
 
 
-- name: Ensure iRODS indexing plugins are pinned
+- name: Ensure iRODS indexing plugins are pinned (Ubuntu)
   ansible.builtin.template:
     src: 'irods_indexing.pref.j2'
     dest: '/etc/apt/preferences.d/irods_indexing.pref'
@@ -57,6 +68,14 @@
     owner: 'root'
     group: 'root'
   when: ansible_os_family == 'Debian' and enable_open_search
+
+
+- name: Ensure iRODS indexing plugin packages have version locks (EL)
+  community.general.dnf_versionlock:
+    name:
+      - "{{ irods_idp_package_new }}"
+      - "{{ irods_esp_package_new }}"
+  when: not ansible_check_mode and enable_open_search and ansible_os_family == 'RedHat'
 
 
 - name: Flush handlers to restart iRODS if needed

--- a/roles/irods_icommands/tasks/main-tasks.yml
+++ b/roles/irods_icommands/tasks/main-tasks.yml
@@ -18,7 +18,7 @@
   when: not irods_server.stat.exists and not ansible_check_mode
 
 
-- name: Ensure iRODS iCommands is pinned
+- name: Ensure iRODS iCommands is pinned (Ubuntu)
   ansible.builtin.template:
     src: 'irods_icommands.pref.j2'
     dest: '/etc/apt/preferences.d/irods_icommands.pref'
@@ -28,7 +28,7 @@
   when: ansible_os_family == 'Debian'
 
 
-- name: Ensure iRODS iCommands version is locked
+- name: Ensure iRODS iCommands version is locked (EL)
   community.general.dnf_versionlock:
     name: '{{ irods_icommands_package_new }}'
     state: present

--- a/roles/irods_resource/tasks/main.yml
+++ b/roles/irods_resource/tasks/main.yml
@@ -29,7 +29,7 @@
   when: not ansible_check_mode
 
 
-- name: Ensure iRODS resource server is pinned
+- name: Ensure iRODS resource server is pinned (Ubuntu)
   ansible.builtin.template:
     src: 'irods_resource.pref.j2'
     dest: '/etc/apt/preferences.d/irods_resource.pref'
@@ -37,6 +37,16 @@
     owner: 'root'
     group: 'root'
   when: ansible_os_family == 'Debian'
+
+
+- name: Ensure iRODS packages have version locks (EL)
+  community.general.dnf_versionlock:
+    name:
+      - "{{ irods_server_package_new }}"
+      - "{{ irods_prep_package_new }}"
+      # irods-runtime package is locked by irods_runtime role instead
+    state: present
+  when: ansible_os_family == 'RedHat'
 
 
 - name: Flush handlers to restart iRODS if needed

--- a/roles/irods_runtime/tasks/main-tasks.yml
+++ b/roles/irods_runtime/tasks/main-tasks.yml
@@ -19,7 +19,7 @@
     state: present
 
 
-- name: Ensure iRODS runtime is pinned
+- name: Ensure iRODS runtime package is pinned (Ubuntu)
   ansible.builtin.template:
     src: 'irods_runtime.pref.j2'
     dest: '/etc/apt/preferences.d/irods_runtime.pref'
@@ -29,7 +29,7 @@
   when: ansible_os_family == 'Debian'
 
 
-- name: Ensure iRODS runtime version is locked
+- name: Ensure iRODS runtime version is locked (EL)
   community.general.dnf_versionlock:
     name: "{{ irods_runtime_package_new }}"
     state: present

--- a/roles/yoda_zabbix_system/tasks/install-redhat.yml
+++ b/roles/yoda_zabbix_system/tasks/install-redhat.yml
@@ -40,3 +40,9 @@
     name: '{{ zabbix_agent.package }}'
     state: present
   when: zabbix_agent_repo.results
+
+
+- name: Ensure Zabbix agent2 package has version locks
+  community.general.dnf_versionlock:
+    name: '{{ zabbix_agent.package }}'
+    state: present


### PR DESCRIPTION
Ensure that iRODS and Zabbix agent packages have version locks:
- These packages, especially the iRODS ones, must not be updated during regular software updates. They are tightly integrated with Yoda, and upgrading them in situations other than Yoda upgrades is likely to break the application.
- Locking iRODS package versions also makes it easier to install regular OS security updates, since it removes a potential source of version conflicts.