### PR TITLE
Remove deprecated parseable option from ansible-lint

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -5,8 +5,6 @@ skip_list:
   - var-naming
   - yaml[line-length]
 
-parseable: true
-
 mock_modules:
   - irods_advanced
   - irods_config


### PR DESCRIPTION
We found out that the ansible-lint job in the rc-2.0.2 was failing because [the `parseable` option has been deprecated](url). This is technically not an issue in development yet because we pinned to v25.12.2. The rc-2.0.2 was also supposed to be pinned to v25.9.0, but for some reason the ansible-lint job was pulling the latest commit of ansible-lint instead, hence why the job started failing. This PR already removes the option to prevent future issues.