### PR TITLE
YDA-6586: add Zabbix resource vault check script

### DIFF
--- a/roles/yoda_zabbix_irodscommon/tasks/main.yml
+++ b/roles/yoda_zabbix_irodscommon/tasks/main.yml
@@ -51,11 +51,15 @@
     state: directory
 
 
-- name: Copy irods log read script
+- name: Copy iRODS check scripts
   ansible.builtin.copy:
-    src: /etc/zabbix/yoda-zabbix/zabbix-irodscommon/read-irods-logs.py
+    src: "/etc/zabbix/yoda-zabbix/zabbix-irodscommon/{{ item }}"
     dest: /var/lib/irods/bin
     mode: '0770'
     owner: "{{ irods_service_account }}"
     group: "{{ irods_service_account }}"
     remote_src: true
+  with_items:
+    - read-irods-logs.py
+    - test-irods-available.py
+    - test-resource-mount-points.py


### PR DESCRIPTION
Add Zabbix check script for presence of vault directories of unixfilesystem resources. This helps detect situations in which iRODS vault volumes have not been mounted correctly.

Also add separate check for availability of iRODS itself, since this check won't work if iRODS is unavailable.