### PR TITLE
YDA-6767: fix msgspec issue with EUS

### DIFF
--- a/docker/images/yoda_eus/yoda-external-user-service-vhost.conf
+++ b/docker/images/yoda_eus/yoda-external-user-service-vhost.conf
@@ -15,6 +15,7 @@
     </Directory>
 
     WSGIDaemonProcess yoda_eus_noapi user=yodadeployment group=yodadeployment threads=5 python-home=/var/www/extuser/yoda-external-user-service/venv
+    WSGIApplicationGroup %{GLOBAL}
     WSGIProcessGroup yoda_eus_noapi
     WSGIScriptAlias / /var/www/extuser/yoda_eus_noapi.wsgi
     WSGIScriptReloading On
@@ -54,6 +55,7 @@ Listen 8443
     </Directory>
 
     WSGIDaemonProcess yoda_eus_api user=yodadeployment group=yodadeployment threads=5 python-home=/var/www/extuser/yoda-external-user-service/venv
+    WSGIApplicationGroup %{GLOBAL}
     WSGIProcessGroup yoda_eus_api
     WSGIScriptAlias / /var/www/extuser/yoda_eus_api.wsgi
     WSGIScriptReloading On

--- a/roles/yoda_external_user_service/templates/yoda-external-user-service-vhost.conf.j2
+++ b/roles/yoda_external_user_service/templates/yoda-external-user-service-vhost.conf.j2
@@ -31,6 +31,7 @@ Listen {{ yoda_eus_port }}
 
     WSGIDaemonProcess yoda_eus_noapi user={{ yoda_deployment_user }} group={{ yoda_deployment_user }} threads=5 python-home=/var/www/extuser/yoda-external-user-service/venv
     WSGIProcessGroup yoda_eus_noapi
+    WSGIApplicationGroup %{GLOBAL}
     WSGIScriptAlias / /var/www/extuser/yoda_eus_noapi.wsgi
     WSGIScriptReloading On
     WSGIPassAuthorization On
@@ -71,6 +72,7 @@ Listen {{ eus_api_port }}
     </Directory>
 
     WSGIDaemonProcess yoda_eus_api user={{ yoda_deployment_user }} group={{ yoda_deployment_user }} threads=5 python-home=/var/www/extuser/yoda-external-user-service/venv
+    WSGIApplicationGroup %{GLOBAL}
     WSGIProcessGroup yoda_eus_api
     WSGIScriptAlias / /var/www/extuser/yoda_eus_api.wsgi
     WSGIScriptReloading On


### PR DESCRIPTION
This change is related to a problem where either the API or UI (NOAPI) application part of EUS failed on importing msgspec, which is used for serialization of session data in newer versions of Flask-Session. This then resulted in either EUS API failures or issues with direct end user requests to EUS. This problem appears to be a variation on a known issue with some native extensions that can't work in subinterpreters other than the first one.

See also https://modwsgi.readthedocs.io/en/latest/user-guides/application-issues.html#python-simplified-gil-state-api for context.