### PR TITLE
YDA-6783: extract Docker param passwords

### DIFF
--- a/docker/compose-with-bind-mounts/.env
+++ b/docker/compose-with-bind-mounts/.env
@@ -1,0 +1,5 @@
+# Hash value of the test user password. The default value is a hash for
+# the password "test".
+# You can generate a password hash using the Linux mkpasswd utility. For example:
+# $ mkpasswd --method=SHA-512 test
+TEST_USER_PASSWORD_HASH='$6$rounds=656000$UYCy5.rN8/Nr5ooZ$.D2DtHyqjMIwQePZ8oGBXkEKTtOeyVPsSK1Kzn/DtIBojPh8ZGxOzVtlrRFMumtgcO7CWzgMAQqxJUORvGiFy0'

--- a/docker/compose-with-bind-mounts/docker-compose.yml
+++ b/docker/compose-with-bind-mounts/docker-compose.yml
@@ -21,6 +21,8 @@ services:
     build:
       context: ../images/yoda_irods_icat
     restart: unless-stopped
+    environment:
+      - TEST_USER_PASSWORD_HASH=${TEST_USER_PASSWORD_HASH}
     volumes:
       - type: bind
         source: ./v_yoda_ruleset

--- a/docker/compose/.env
+++ b/docker/compose/.env
@@ -1,0 +1,5 @@
+# Hash value of the test users' passwords. The default value is a hash for
+# the password "test".
+# You can generate a password hash using the Linux mkpasswd utility. For example:
+# $ mkpasswd --method=SHA-512 test
+TEST_USER_PASSWORD_HASH='$6$rounds=656000$UYCy5.rN8/Nr5ooZ$.D2DtHyqjMIwQePZ8oGBXkEKTtOeyVPsSK1Kzn/DtIBojPh8ZGxOzVtlrRFMumtgcO7CWzgMAQqxJUORvGiFy0'

--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -21,6 +21,8 @@ services:
     volumes:
       - public_metadata:/public/var/www/moai/metadata
       - public_landingpages:/public/var/www/landingpages
+    environment:
+      - TEST_USER_PASSWORD_HASH=${TEST_USER_PASSWORD_HASH}
     restart: unless-stopped
 
   db:

--- a/docker/images/yoda_irods_icat/irods-icat-init.sh
+++ b/docker/images/yoda_irods_icat/irods-icat-init.sh
@@ -39,6 +39,13 @@ function start_service {
   sleep infinity
 }
 
+# Override test user passwords with user-defined values
+before_update "Setting test user passwords"
+for user in researcher viewer groupmanager datamanager functionaladmingroup functionaladmincategory functionaladminpriv technicaladmin projectmanager dacmember ; \
+do usermod -p "$TEST_USER_PASSWORD_HASH" "$user"
+done
+progress_update "Setting test user passwords complete"
+
 if [ -f "/container_initialized" ]
 then echo "Container has already been initialized. Starting service."
      start_service


### PR DESCRIPTION
In the Docker setup, extract a parameter for the
hash value of the test users' passwords, so that a technical admin can configure non-default passwords.