### PR TITLE
YDA-6847: Workaround for pyoai dependency issues

### DIFF
--- a/docker/images/yoda_public/Dockerfile
+++ b/docker/images/yoda_public/Dockerfile
@@ -50,7 +50,7 @@ RUN mkdir -p /var/www/moai /var/www/moai/metadata && \
     chmod 0755 /var/www/moai /var/www/moai/metadata && \
     chown -R yodadeployment:yodadeployment /var/www/moai && \
     virtualenv --python /usr/bin/python3 /var/www/moai/yoda-moai/venv && \
-    /var/www/moai/yoda-moai/venv/bin/pip3 install pip==25.0
+    /var/www/moai/yoda-moai/venv/bin/pip3 install pip==26.0.1
 
 ## Install PySQLite3 for MOAI
 ENV C_INCLUDE_PATH /usr/include/python3.12:/usr/include
@@ -59,7 +59,12 @@ RUN /var/www/moai/yoda-moai/venv/bin/pip3 install pysqlite3==0.5.0
 
 ## Install MOAI itself
 ENV C_INCLUDE_PATH /usr/include/python3.12
-RUN /var/www/moai/yoda-moai/venv/bin/pip3 install -e /var/www/moai/yoda-moai
+RUN /var/www/moai/yoda-moai/venv/bin/pip3 install wheel==0.46.3 && \
+    /var/www/moai/yoda-moai/venv/bin/pip3 install setuptools==81.0.0 && \
+    /var/www/moai/yoda-moai/venv/bin/pip3 install lxml==6.0.2 && \
+    /var/www/moai/yoda-moai/venv/bin/pip3 install six==1.17.0 && \
+    /var/www/moai/yoda-moai/venv/bin/pip3 install --no-build-isolation "pyoai @ git+https://github.com/infrae/pyoai.git@2.5.1" && \
+    /var/www/moai/yoda-moai/venv/bin/pip3 install -e /var/www/moai/yoda-moai
 
 ## Configure and initialize MOAI
 COPY moai-settings.ini /var/www/moai/settings.ini

--- a/roles/yoda_moai/tasks/main.yml
+++ b/roles/yoda_moai/tasks/main.yml
@@ -60,17 +60,36 @@
   become: true
   ansible.builtin.pip:
     name:
-      - pip==25.0
+      - pip==26.0.1
       - virtualenv==20.28.0
     executable: /var/www/moai/yoda-moai/venv/bin/pip3
 
 
-- name: Ensure Yoda MOAI virtualenv exists
+# We're installing pyoai dependencies manually, because we need to
+# disable build isolation (see below).
+- name: Manually install dependencies of pyoai
   become_user: '{{ yoda_moai_user }}'
   become: true
-  ansible.builtin.command: "{{ yoda_moai_home }}/yoda-moai/venv/bin/python3 -m virtualenv {{ yoda_moai_home }}/yoda-moai/venv"
-  args:
-    creates: "{{ yoda_moai_home }}/yoda-moai/venv/bin/activate_this.py"
+  ansible.builtin.pip:
+    name:
+      - wheel==0.46.3
+      - setuptools==81.0.0
+      - lxml==6.0.2
+      - six==1.17.0
+    executable: /var/www/moai/yoda-moai/venv/bin/pip3
+
+
+# Build isolation is disabled in order to be able to work around
+# pyoai still depending on pkg_resources, which needs an older
+# setuptools version (see ticket YDA-6847)
+- name: Manually install pyoai dependency
+  become_user: '{{ yoda_moai_user }}'
+  become: true
+  ansible.builtin.pip:
+    name:
+      - "pyoai @ git+https://github.com/infrae/pyoai.git@2.5.1"
+    extra_args: --no-build-isolation
+    executable: /var/www/moai/yoda-moai/venv/bin/pip3
 
 
 # We use the PySqlite3 dialect to avoid compatibility issues between SQLAlchemy


### PR DESCRIPTION
Add temporary workaround to MOAI installation to use older setuptools version. Newer setuptools versions break MOAI because pyoai relies on pkg_resources, which has been removed from setuptools.

This is meant as a temporary workaround. In the long term, we'll probably need a new maintenance release for pyoai that fixes the root cause (either upstream or in a fork).