### PR TITLE
YDA-6866: Fix log setup for iRODS 5.0.x

### DIFF
--- a/docker/images/yoda_irods_icat/rsyslogd-irods.conf
+++ b/docker/images/yoda_irods_icat/rsyslogd-irods.conf
@@ -7,7 +7,7 @@ $DirCreateMode 0755
 
 module(load="omprog")
 
-if ($programname == 'irodsServer' or $programname == "irodsDelayServer" or $programname == "irodsAgent") then {
-        action(type="omprog" name="transformer" binary="/usr/local/bin/irods-log-transform.py")
-        stop
+if (re_match($programname, "^irods(Server|DelayServer|Agent)")) then {
+    action(type="omprog" name="transformer" binary="/usr/local/bin/irods-log-transform.py")
+    stop
 }

--- a/docker/images/yoda_irods_icat/server_config.json
+++ b/docker/images/yoda_irods_icat/server_config.json
@@ -69,7 +69,7 @@
         "network": "info",
         "resource": "info",
         "rule_engine": "info",
-        "server": "debug",
+        "server": "info",
         "sql": "info"
     },
     "match_hash_policy": "compatible",

--- a/roles/irods_log/defaults/main.yml
+++ b/roles/irods_log/defaults/main.yml
@@ -19,4 +19,4 @@ irods_log_settings_levels:
   network: info
   resource: info
   rule_engine: info
-  server: debug  # Debug level is needed to print log output from rule code
+  server: info

--- a/roles/irods_log/templates/rsyslogd-irods.conf.j2
+++ b/roles/irods_log/templates/rsyslogd-irods.conf.j2
@@ -9,7 +9,7 @@ $DirCreateMode 0755
 
 module(load="omprog")
 
-if ($programname == 'irodsServer' or $programname == "irodsDelayServer" or $programname == "irodsAgent") then {
-        action(type="omprog" name="transformer" binary="/usr/local/bin/irods-log-transform.py")
-        stop
+if (re_match($programname, "^irods(Server|DelayServer|Agent)")) then {
+    action(type="omprog" name="transformer" binary="/usr/local/bin/irods-log-transform.py")
+    stop
 }


### PR DESCRIPTION
Ensure that legacy rule language log messages get processed by rsyslog, and finetune log levels.