### PR TITLE
YDA-6887: add PostgreSQL param autovacuum workers

### DIFF
--- a/docs/administration/configuring-yoda.md
+++ b/docs/administration/configuring-yoda.md
@@ -337,6 +337,7 @@ postgresql_random_page_cost            | Planner's estimate of the cost of a non
 postgresql_log_line_prefix             | Format of log message prefix in the PostgreSQL log, for adding timestamps etc. to log messages. The default value adds a timestamp and process number, which is sufficient for most purposes. It might be useful to log additional information in specific situations, such as when troubleshooting database issues.
 postgresql_log_min_duration_statement  | Minimum number of milliseconds for slow query logging (default: -1 / disabled)
 postgresql_log_autovacuum_min_duration | Minimum number of milliseconds for logging slow autovacuum actions (default: -1 / disabled)
+postgresql_autovacuum_max_workers      | Maximum number of autovacuum worker processes (default: 3)
 postgresql_timezone                    | Timezone that PostgreSQL uses. Defaults to Europe/Amsterdam.
 
 ### PgBouncer configuration

--- a/roles/postgresql/defaults/main.yml
+++ b/roles/postgresql/defaults/main.yml
@@ -48,6 +48,10 @@ postgresql_effective_cache_size: 384MB
 # Solid-state drives might be better modeled with a lower value e.g., "1.1"
 postgresql_random_page_cost: "1.1"
 
+# Maximum number of autovacuum worker processes. May need to be increased
+# if autovacuum isn't able to keep up with changes.
+postgresql_autovacuum_max_workers: 3
+
 # PostgreSQL logging configuration
 postgresql_log_line_prefix: '%m [%p] '
 postgresql_log_min_duration_statement: -1

--- a/roles/postgresql/templates/postgresql-Debian.conf.j2
+++ b/roles/postgresql/templates/postgresql-Debian.conf.j2
@@ -645,7 +645,8 @@ cluster_name = '{{ pgsql_version }}/main'			# added to process titles if nonempt
 
 #autovacuum = on			# Enable autovacuum subprocess?  'on'
 					# requires track_counts to also be on.
-#autovacuum_max_workers = 3		# max number of autovacuum subprocesses
+autovacuum_max_workers = {{ postgresql_autovacuum_max_workers }}
+					# max number of autovacuum subprocesses
 					# (change requires restart)
 #autovacuum_naptime = 1min		# time between autovacuum runs
 #autovacuum_vacuum_threshold = 50	# min number of row updates before

--- a/roles/postgresql/templates/postgresql-RedHat.conf.j2
+++ b/roles/postgresql/templates/postgresql-RedHat.conf.j2
@@ -641,7 +641,8 @@ log_timezone = '{{ postgresql_timezone }}'
 
 #autovacuum = on			# Enable autovacuum subprocess?  'on'
 					# requires track_counts to also be on.
-#autovacuum_max_workers = 3		# max number of autovacuum subprocesses
+autovacuum_max_workers = {{ postgresql_autovacuum_max_workers }}
+					# max number of autovacuum subprocesses
 					# (change requires restart)
 #autovacuum_naptime = 1min		# time between autovacuum runs
 #autovacuum_vacuum_threshold = 50	# min number of row updates before


### PR DESCRIPTION
Add parameter for maximum number of autovacuum worker processes in PostgreSQL, so that technical admins can increase the number of processes when needed.