### PR TITLE
Ensure runtime directory for irods user is created after reboot

### DIFF
--- a/roles/irods_icat/tasks/main.yml
+++ b/roles/irods_icat/tasks/main.yml
@@ -213,8 +213,6 @@
   with_items:
     - path: /var/lib/irods
       recurse: true
-    - path: /var/run/irods
-      recurse: true
     - path: /etc/irods
       recurse: false
 

--- a/roles/irods_icat/templates/irods.service.j2
+++ b/roles/irods_icat/templates/irods.service.j2
@@ -9,6 +9,7 @@ KillMode=mixed
 Restart=on-failure
 User={{ irods_service_account }}
 Group={{ irods_service_account }}
+RuntimeDirectory=irods
 WorkingDirectory=/var/lib/irods
 RestartPreventExitStatus=255
 LimitNOFILE={{ irods_max_open_files | string }}

--- a/roles/irods_resource/templates/irods.service.j2
+++ b/roles/irods_resource/templates/irods.service.j2
@@ -9,6 +9,7 @@ KillMode=mixed
 Restart=on-failure
 User={{ irods_service_account }}
 Group={{ irods_service_account }}
+RuntimeDirectory=irods
 WorkingDirectory=/var/lib/irods
 RestartPreventExitStatus=255
 LimitNOFILE={{ irods_max_open_files | string }}


### PR DESCRIPTION
This PR makes sure that the runtime directory `/var/run/irods` is created after system is restarted