### PR TITLE
YDA-6918-change-output-file-extension

### DIFF
--- a/roles/yoda_report/files/gather-group-stats.sh
+++ b/roles/yoda_report/files/gather-group-stats.sh
@@ -14,5 +14,5 @@ YODA_REPORT_SERVER_HOST="${YODA_REPORT_SERVER_HOST:?host not set}"
 YODA_REPORT_SERVER_FINANCIAL_DATA_DIR="${YODA_REPORT_SERVER_FINANCIAL_DATA_DIR:?remote dir not set}"
 
 # Generate report and transfer
-/var/lib/irods/yoda-clienttools/venv/bin/yreport_oldvsnewdata -q --use-create-time -e "$INSTANCE" -y 2.0 > "/var/yoda-financial-data/stats.yaml"
-scp -i "$YODA_REPORT_SERVER_PRIV_KEY_LOC" "/var/yoda-financial-data/stats.yaml" "$YODA_REPORT_SERVER_USER_ACCOUNT@$YODA_REPORT_SERVER_HOST:$YODA_REPORT_SERVER_FINANCIAL_DATA_DIR/$INSTANCE.stats.yml"
+/var/lib/irods/yoda-clienttools/venv/bin/yreport_oldvsnewdata -q --use-create-time -e "$INSTANCE" -y 2.0 > "/var/yoda-financial-data/stats.csv"
+scp -i "$YODA_REPORT_SERVER_PRIV_KEY_LOC" "/var/yoda-financial-data/stats.csv" "$YODA_REPORT_SERVER_USER_ACCOUNT@$YODA_REPORT_SERVER_HOST:$YODA_REPORT_SERVER_FINANCIAL_DATA_DIR/$INSTANCE.stats.csv"


### PR DESCRIPTION
Update the gather-group-stats.sh script so that the output generated by yreport_oldvsnewdata is written as a .csv file instead of a .yml file.